### PR TITLE
Add anchor link props

### DIFF
--- a/components/button/component.stories.tsx
+++ b/components/button/component.stories.tsx
@@ -36,3 +36,10 @@ FullWidth.args = {
   disabled: false,
   className: 'w-full',
 };
+
+export const WithNextLinkProps = Template.bind({});
+WithNextLinkProps.args = {
+  anchorLinkProps: { shallow: true, as: 'next-link-anchor' },
+  children: 'Button',
+  href: '/',
+};

--- a/components/button/component.tsx
+++ b/components/button/component.tsx
@@ -39,6 +39,7 @@ export type ButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & AnchorButton
 export type AnchorProps = AnchorHTMLAttributes<HTMLAnchorElement> & AnchorButtonProps & {
   href?: string;
   disabled?: boolean;
+  anchorLinkProps?: Record<string, unknown>
 };
 
 // Input/output options
@@ -72,9 +73,10 @@ export const LinkAnchor: FC<AnchorProps> = ({
   className,
   disabled,
   href,
+  anchorLinkProps,
   ...restProps
 }: AnchorProps) => (
-  <Link href={href}>
+  <Link href={href} {...anchorLinkProps}>
     <a
       className={buildClassName({
         className, disabled, size, theme,

--- a/components/button/component.tsx
+++ b/components/button/component.tsx
@@ -1,7 +1,7 @@
 import {
   ButtonHTMLAttributes, AnchorHTMLAttributes, FC,
 } from 'react';
-import Link from 'next/link';
+import Link, { LinkProps } from 'next/link';
 import cx from 'classnames';
 
 const THEME = {
@@ -39,7 +39,7 @@ export type ButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & AnchorButton
 export type AnchorProps = AnchorHTMLAttributes<HTMLAnchorElement> & AnchorButtonProps & {
   href?: string;
   disabled?: boolean;
-  anchorLinkProps?: Record<string, unknown>
+  anchorLinkProps?: LinkProps
 };
 
 // Input/output options

--- a/components/map/component.tsx
+++ b/components/map/component.tsx
@@ -134,6 +134,7 @@ export const Map: FC<MapProps> = ({
       mapContainerRef.current.offsetWidth <= 0
       || mapContainerRef.current.offsetHeight <= 0
     ) {
+      // eslint-disable-next-line no-console
       console.error("mapContainerRef doesn't have dimensions");
       return null;
     }


### PR DESCRIPTION
This PR adds an anchorLinkProps prop to the Button component. This prop helps to include in the Link other props that the next/link component could have: 

https://nextjs.org/docs/api-reference/next/link

Types can maybe be improved