### PR TITLE
Add setup for unit tests

### DIFF
--- a/cypress-unit.json
+++ b/cypress-unit.json
@@ -1,0 +1,5 @@
+{
+  "integrationFolder": "cypress/unit",
+  "screenshotOnRunFailure": false,
+  "video": false
+}

--- a/cypress/unit/unit-example.spec.js
+++ b/cypress/unit/unit-example.spec.js
@@ -1,0 +1,5 @@
+describe('Unit test example', () => {
+  it('should work', () => {
+    expect([]).to.deep.equal([]);
+  })
+});

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "storybook:build": "yarn storybook:styles:prod && build-storybook -s ./public -c .storybook",
     "cypress:open": "cypress open",
     "cypress:run": "cypress run",
+    "cypress:unit:open": "cypress open --config-file cypress-unit.json",
+    "cypress:unit:run": "cypress run --config-file cypress-unit.json",
     "postinstall": "husky install"
   },
   "dependencies": {


### PR DESCRIPTION
# Set up the unit tests on cypress.

- Use two different actions on package.json: `cypress:unit:open` and `cypress:unit:run` that will run with a different config file `cypress-unit.json`. This will allow us not to wait for the server to run and run the tests immediately.

- The tests should be included in the unit folder. One example is included already