### PR TITLE
Fix the modal's responsiveness

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -3,6 +3,8 @@ import React from 'react';
 import { themes } from '@storybook/theming';
 import { OverlayProvider } from '@react-aria/overlays';
 
+import { MediaContextProvider } from 'components/media-query';
+
 export const parameters = {
   actions: { argTypesRegex: '^on[A-Z].*' },
   options: {
@@ -24,7 +26,9 @@ export const decorators = [
   (Story) => {
     return (
       <OverlayProvider>
-        <div>{Story()}</div>
+        <MediaContextProvider>
+          <div>{Story()}</div>
+        </MediaContextProvider>
       </OverlayProvider>
     );
   },

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "postinstall": "husky install"
   },
   "dependencies": {
+    "@artsy/fresnel": "^3.4.0",
     "@deck.gl/core": "8.4.16",
     "@deck.gl/geo-layers": "8.4.16",
     "@deck.gl/layers": "8.4.16",
@@ -77,7 +78,6 @@
     "react-popper": "^2.2.5",
     "react-query": "^3.16.0",
     "react-redux": "^7.2.4",
-    "rooks": "^5.10.0",
     "tailwindcss": "^2.1.2",
     "use-debounce": "^6.0.1",
     "validate.js": "^0.13.1"

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "react-popper": "^2.2.5",
     "react-query": "^3.16.0",
     "react-redux": "^7.2.4",
+    "rooks": "^5.10.0",
     "tailwindcss": "^2.1.2",
     "use-debounce": "^6.0.1",
     "validate.js": "^0.13.1"

--- a/src/components/media-query/index.ts
+++ b/src/components/media-query/index.ts
@@ -1,0 +1,26 @@
+import { createMedia } from '@artsy/fresnel';
+
+import { screens } from 'styles.config';
+
+const ExampleAppMedia = createMedia<
+  { breakpoints: Record<string, number> },
+  '0' | keyof typeof screens,
+  never
+>({
+  breakpoints: Object.keys(screens).reduce(
+    (res, key) => ({
+      ...res,
+      // We extract the pixel value of the breakpoint (e.g. `'1024px'` => `1024`)
+      [key]: parseInt(screens[key].match(/(\d+)px/)?.[1] ?? '0', 10),
+    }),
+    {
+      // We need a breakpoint starting at 0 to target screens smaller than sm
+      '0': 0,
+    }
+  ),
+});
+
+// Make styles for injection into the header of the page
+export const mediaStyles = ExampleAppMedia.createMediaStyle();
+
+export const { Media, MediaContextProvider } = ExampleAppMedia;

--- a/src/components/modal/component.tsx
+++ b/src/components/modal/component.tsx
@@ -86,10 +86,12 @@ export const Modal: FC<ModalProps> = ({
     : {
         initial: {
           opacity: 0,
+          x: '0',
           y: '-60%',
         },
         animate: {
           opacity: 1,
+          x: '0',
           y: '-50%',
           transition: {
             delay: 0.125,
@@ -97,6 +99,7 @@ export const Modal: FC<ModalProps> = ({
         },
         exit: {
           opacity: 0,
+          x: '0',
           y: '-60%',
           transition: {
             delay: 0,

--- a/src/components/modal/component.tsx
+++ b/src/components/modal/component.tsx
@@ -21,6 +21,7 @@ export const Modal: FC<ModalProps> = ({
   dismissable = true,
   size = 'default',
   children,
+  scrollable = true,
   className,
   onDismiss,
 }: ModalProps) => {
@@ -103,6 +104,15 @@ export const Modal: FC<ModalProps> = ({
         },
       };
 
+  const modalContent = Children.map(children, (child) => {
+    if (isValidElement(child)) {
+      return cloneElement(child, {
+        onDismiss,
+      });
+    }
+    return null;
+  });
+
   usePreventScroll({ isDisabled: !open });
 
   return (
@@ -141,15 +151,8 @@ export const Modal: FC<ModalProps> = ({
                     </div>
                   )}
 
-                  {/* Children */}
-                  {Children.map(children, (child) => {
-                    if (isValidElement(child)) {
-                      return cloneElement(child, {
-                        onDismiss,
-                      });
-                    }
-                    return null;
-                  })}
+                  {!scrollable && modalContent}
+                  {scrollable && <div className="overflow-y-auto flex-grow-1">{modalContent}</div>}
                 </motion.div>
               </div>
             </FocusScope>

--- a/src/components/modal/component.tsx
+++ b/src/components/modal/component.tsx
@@ -6,6 +6,7 @@ import { useDialog } from '@react-aria/dialog';
 import { FocusScope } from '@react-aria/focus';
 import { useOverlay, usePreventScroll, useModal, OverlayContainer } from '@react-aria/overlays';
 import { AnimatePresence, motion } from 'framer-motion';
+import { useMediaMatch } from 'rooks';
 
 import Icon from 'components/icon';
 
@@ -36,6 +37,72 @@ export const Modal: FC<ModalProps> = ({
   const { modalProps } = useModal();
   const { dialogProps } = useDialog({ 'aria-label': title }, containerRef);
 
+  // 640px corresponds to the Tailwind's sm breakpoint
+  const isSmViewport = useMediaMatch('(min-width: 640px)');
+
+  const overlayFramerVariants = {
+    initial: {
+      opacity: 0,
+    },
+    animate: {
+      opacity: 1,
+      transition: {
+        delay: 0,
+      },
+    },
+    exit: {
+      opacity: 0,
+      transition: {
+        delay: 0.125,
+      },
+    },
+  };
+
+  const contentFramerVariants = isSmViewport
+    ? {
+        initial: {
+          opacity: 0,
+          x: '-50%',
+          y: '-60%',
+        },
+        animate: {
+          opacity: 1,
+          x: '-50%',
+          y: '-50%',
+          transition: {
+            delay: 0.125,
+          },
+        },
+        exit: {
+          opacity: 0,
+          x: '-50%',
+          y: '-60%',
+          transition: {
+            delay: 0,
+          },
+        },
+      }
+    : {
+        initial: {
+          opacity: 0,
+          y: '-60%',
+        },
+        animate: {
+          opacity: 1,
+          y: '-50%',
+          transition: {
+            delay: 0.125,
+          },
+        },
+        exit: {
+          opacity: 0,
+          y: '-60%',
+          transition: {
+            delay: 0,
+          },
+        },
+      };
+
   usePreventScroll({ isDisabled: !open });
 
   return (
@@ -43,47 +110,19 @@ export const Modal: FC<ModalProps> = ({
       {open && (
         <OverlayContainer>
           <motion.div
-            initial={{
-              opacity: 0,
-            }}
-            animate={{
-              opacity: 1,
-              transition: {
-                delay: 0,
-              },
-            }}
-            exit={{
-              opacity: 0,
-              transition: {
-                delay: 0.125,
-              },
-            }}
+            variants={overlayFramerVariants}
+            initial="initial"
+            animate="animate"
+            exit="exit"
             className={cx({ [OVERLAY_CLASSES]: true })}
           >
             <FocusScope contain restoreFocus autoFocus>
               <div {...overlayProps} {...dialogProps} {...modalProps} ref={containerRef}>
                 <motion.div
-                  initial={{
-                    opacity: 0,
-                    y: '-60%',
-                    x: '-50%',
-                  }}
-                  animate={{
-                    opacity: 1,
-                    y: '-50%',
-                    x: '-50%',
-                    transition: {
-                      delay: 0.125,
-                    },
-                  }}
-                  exit={{
-                    opacity: 0,
-                    y: '-60%',
-                    x: '-50%',
-                    transition: {
-                      delay: 0,
-                    },
-                  }}
+                  variants={contentFramerVariants}
+                  initial="initial"
+                  animate="animate"
+                  exit="exit"
                   className={cx({ [CONTENT_CLASSES[size]]: true, [className]: !!className })}
                   style={{
                     maxHeight: '90%',

--- a/src/components/modal/component.tsx
+++ b/src/components/modal/component.tsx
@@ -1,120 +1,15 @@
-import { Children, FC, cloneElement, isValidElement, useRef } from 'react';
+import { FC } from 'react';
 
-import cx from 'classnames';
+import { usePreventScroll, OverlayContainer } from '@react-aria/overlays';
+import { AnimatePresence } from 'framer-motion';
 
-import { useDialog } from '@react-aria/dialog';
-import { FocusScope } from '@react-aria/focus';
-import { useOverlay, usePreventScroll, useModal, OverlayContainer } from '@react-aria/overlays';
-import { AnimatePresence, motion } from 'framer-motion';
-import { useMediaMatch } from 'rooks';
+import { Media } from 'components/media-query';
 
-import Icon from 'components/icon';
-import { screens } from 'styles.config';
-
-import CLOSE_SVG from 'svgs/ui/close.svg?sprite';
-
-import { CONTENT_CLASSES, OVERLAY_CLASSES } from './constants';
+import ModalContent from './content';
 import type { ModalProps } from './types';
 
-export const Modal: FC<ModalProps> = ({
-  title,
-  open,
-  dismissable = true,
-  size = 'default',
-  children,
-  scrollable = true,
-  className,
-  onDismiss,
-}: ModalProps) => {
-  const containerRef = useRef();
-  const { overlayProps } = useOverlay(
-    {
-      isKeyboardDismissDisabled: !dismissable,
-      isDismissable: dismissable,
-      isOpen: open,
-      onClose: onDismiss,
-    },
-    containerRef
-  );
-  const { modalProps } = useModal();
-  const { dialogProps } = useDialog({ 'aria-label': title }, containerRef);
-
-  const isSmViewport = useMediaMatch(`(min-width: ${screens.sm})`);
-
-  const overlayFramerVariants = {
-    initial: {
-      opacity: 0,
-    },
-    animate: {
-      opacity: 1,
-      transition: {
-        delay: 0,
-      },
-    },
-    exit: {
-      opacity: 0,
-      transition: {
-        delay: 0.125,
-      },
-    },
-  };
-
-  const contentFramerVariants = isSmViewport
-    ? {
-        initial: {
-          opacity: 0,
-          x: '-50%',
-          y: '-60%',
-        },
-        animate: {
-          opacity: 1,
-          x: '-50%',
-          y: '-50%',
-          transition: {
-            delay: 0.125,
-          },
-        },
-        exit: {
-          opacity: 0,
-          x: '-50%',
-          y: '-60%',
-          transition: {
-            delay: 0,
-          },
-        },
-      }
-    : {
-        initial: {
-          opacity: 0,
-          x: '0',
-          y: '-60%',
-        },
-        animate: {
-          opacity: 1,
-          x: '0',
-          y: '-50%',
-          transition: {
-            delay: 0.125,
-          },
-        },
-        exit: {
-          opacity: 0,
-          x: '0',
-          y: '-60%',
-          transition: {
-            delay: 0,
-          },
-        },
-      };
-
-  const modalContent = Children.map(children, (child) => {
-    if (isValidElement(child)) {
-      return cloneElement(child, {
-        onDismiss,
-      });
-    }
-    return null;
-  });
+export const Modal: FC<ModalProps> = (props: ModalProps) => {
+  const { open } = props;
 
   usePreventScroll({ isDisabled: !open });
 
@@ -122,44 +17,12 @@ export const Modal: FC<ModalProps> = ({
     <AnimatePresence>
       {open && (
         <OverlayContainer>
-          <motion.div
-            variants={overlayFramerVariants}
-            initial="initial"
-            animate="animate"
-            exit="exit"
-            className={cx({ [OVERLAY_CLASSES]: true })}
-          >
-            <FocusScope contain restoreFocus autoFocus>
-              <div {...overlayProps} {...dialogProps} {...modalProps} ref={containerRef}>
-                <motion.div
-                  variants={contentFramerVariants}
-                  initial="initial"
-                  animate="animate"
-                  exit="exit"
-                  className={cx({ [CONTENT_CLASSES[size]]: true, [className]: !!className })}
-                  style={{
-                    maxHeight: '90%',
-                  }}
-                >
-                  {dismissable && (
-                    <div className="relative">
-                      <button
-                        type="button"
-                        onClick={onDismiss}
-                        className="absolute flex items-center px-4 py-4 text-sm text-gray-300 right-4 -top-4 focus:text-black hover:text-black"
-                      >
-                        <span className="text-xs">Close</span>
-                        <Icon icon={CLOSE_SVG} className="inline-block w-3 h-3 ml-2 text-black" />
-                      </button>
-                    </div>
-                  )}
-
-                  {!scrollable && modalContent}
-                  {scrollable && <div className="overflow-y-auto flex-grow-1">{modalContent}</div>}
-                </motion.div>
-              </div>
-            </FocusScope>
-          </motion.div>
+          <Media lessThan="sm">
+            <ModalContent {...props} viewport="" />
+          </Media>
+          <Media greaterThanOrEqual="sm">
+            <ModalContent {...props} viewport="sm" />
+          </Media>
         </OverlayContainer>
       )}
     </AnimatePresence>

--- a/src/components/modal/component.tsx
+++ b/src/components/modal/component.tsx
@@ -9,6 +9,7 @@ import { AnimatePresence, motion } from 'framer-motion';
 import { useMediaMatch } from 'rooks';
 
 import Icon from 'components/icon';
+import { screens } from 'styles.config';
 
 import CLOSE_SVG from 'svgs/ui/close.svg?sprite';
 
@@ -38,8 +39,7 @@ export const Modal: FC<ModalProps> = ({
   const { modalProps } = useModal();
   const { dialogProps } = useDialog({ 'aria-label': title }, containerRef);
 
-  // 640px corresponds to the Tailwind's sm breakpoint
-  const isSmViewport = useMediaMatch('(min-width: 640px)');
+  const isSmViewport = useMediaMatch(`(min-width: ${screens.sm})`);
 
   const overlayFramerVariants = {
     initial: {

--- a/src/components/modal/content/component.tsx
+++ b/src/components/modal/content/component.tsx
@@ -1,4 +1,4 @@
-import { Children, FC, cloneElement, isValidElement, useRef } from 'react';
+import { FC, useRef } from 'react';
 
 import cx from 'classnames';
 
@@ -80,15 +80,6 @@ export const ModalContent: FC<ModalContentProps> = ({
     },
   };
 
-  const modalContent = Children.map(children, (child) => {
-    if (isValidElement(child)) {
-      return cloneElement(child, {
-        onDismiss,
-      });
-    }
-    return null;
-  });
-
   return (
     <motion.div
       variants={overlayFramerVariants}
@@ -122,8 +113,8 @@ export const ModalContent: FC<ModalContentProps> = ({
               </div>
             )}
 
-            {!scrollable && modalContent}
-            {scrollable && <div className="overflow-y-auto flex-grow-1">{modalContent}</div>}
+            {!scrollable && children}
+            {scrollable && <div className="overflow-y-auto flex-grow-1">{children}</div>}
           </motion.div>
         </div>
       </FocusScope>

--- a/src/components/modal/content/component.tsx
+++ b/src/components/modal/content/component.tsx
@@ -1,0 +1,134 @@
+import { Children, FC, cloneElement, isValidElement, useRef } from 'react';
+
+import cx from 'classnames';
+
+import { useDialog } from '@react-aria/dialog';
+import { FocusScope } from '@react-aria/focus';
+import { useOverlay, useModal } from '@react-aria/overlays';
+import { motion } from 'framer-motion';
+
+import Icon from 'components/icon';
+
+import CLOSE_SVG from 'svgs/ui/close.svg?sprite';
+
+import { CONTENT_CLASSES, OVERLAY_CLASSES } from './constants';
+import type { ModalContentProps } from './types';
+
+export const ModalContent: FC<ModalContentProps> = ({
+  title,
+  open,
+  dismissable = true,
+  size = 'default',
+  children,
+  scrollable = true,
+  className,
+  onDismiss,
+  viewport,
+}: ModalContentProps) => {
+  const containerRef = useRef();
+  const { overlayProps } = useOverlay(
+    {
+      isKeyboardDismissDisabled: !dismissable,
+      isDismissable: dismissable,
+      isOpen: open,
+      onClose: onDismiss,
+    },
+    containerRef
+  );
+  const { modalProps } = useModal();
+  const { dialogProps } = useDialog({ 'aria-label': title }, containerRef);
+
+  const overlayFramerVariants = {
+    initial: {
+      opacity: 0,
+    },
+    animate: {
+      opacity: 1,
+      transition: {
+        delay: 0,
+      },
+    },
+    exit: {
+      opacity: 0,
+      transition: {
+        delay: 0.125,
+      },
+    },
+  };
+
+  const contentFramerVariants = {
+    initial: {
+      opacity: 0,
+      x: viewport === 'sm' ? '-50%' : '0',
+      y: '-60%',
+    },
+    animate: {
+      opacity: 1,
+      x: viewport === 'sm' ? '-50%' : '0',
+      y: '-50%',
+      transition: {
+        delay: 0.125,
+      },
+    },
+    exit: {
+      opacity: 0,
+      x: viewport === 'sm' ? '-50%' : '0',
+      y: '-60%',
+      transition: {
+        delay: 0,
+      },
+    },
+  };
+
+  const modalContent = Children.map(children, (child) => {
+    if (isValidElement(child)) {
+      return cloneElement(child, {
+        onDismiss,
+      });
+    }
+    return null;
+  });
+
+  return (
+    <motion.div
+      variants={overlayFramerVariants}
+      initial="initial"
+      animate="animate"
+      exit="exit"
+      className={cx({ [OVERLAY_CLASSES]: true })}
+    >
+      <FocusScope contain restoreFocus autoFocus>
+        <div {...overlayProps} {...dialogProps} {...modalProps} ref={containerRef}>
+          <motion.div
+            variants={contentFramerVariants}
+            initial="initial"
+            animate="animate"
+            exit="exit"
+            className={cx({ [CONTENT_CLASSES[size]]: true, [className]: !!className })}
+            style={{
+              maxHeight: '90%',
+            }}
+          >
+            {dismissable && (
+              <div className="relative">
+                <button
+                  type="button"
+                  onClick={onDismiss}
+                  className="absolute flex items-center px-4 py-4 text-sm text-gray-300 right-4 -top-4 focus:text-black hover:text-black"
+                >
+                  <span className="text-xs">Close</span>
+                  <Icon icon={CLOSE_SVG} className="inline-block w-3 h-3 ml-2 text-black" />
+                </button>
+              </div>
+            )}
+
+            {!scrollable && modalContent}
+            {scrollable && <div className="overflow-y-auto flex-grow-1">{modalContent}</div>}
+          </motion.div>
+        </div>
+      </FocusScope>
+    </motion.div>
+  );
+};
+
+export default ModalContent;

--- a/src/components/modal/content/constants.ts
+++ b/src/components/modal/content/constants.ts
@@ -1,0 +1,9 @@
+export const COMMON_CONTENT_CLASSES =
+  'absolute top-1/2 inset-x-4 sm:left-1/2 transform -translate-y-1/2 sm:-translate-x-1/2 outline-none bg-white flex flex-col flex-grow overflow-hidden rounded-3xl py-7';
+export const CONTENT_CLASSES = {
+  narrow: `sm:w-4/6 md:w-1/2 lg:w-5/12 xl:w-1/3 ${COMMON_CONTENT_CLASSES}`,
+  default: `sm:w-4/5 md:w-2/3 lg:1/2 xl:w-2/5 ${COMMON_CONTENT_CLASSES}`,
+  wide: `sm:w-10/12 md:w-10/12 lg:w-10/12 xl:w-8/12 ${COMMON_CONTENT_CLASSES}`,
+};
+
+export const OVERLAY_CLASSES = 'z-50 fixed inset-0 bg-black bg-blur';

--- a/src/components/modal/content/index.ts
+++ b/src/components/modal/content/index.ts
@@ -1,0 +1,2 @@
+export type { ModalContentProps } from './types';
+export { default } from './component';

--- a/src/components/modal/content/types.ts
+++ b/src/components/modal/content/types.ts
@@ -1,0 +1,6 @@
+import { ModalProps } from '..';
+
+export type ModalContentProps = ModalProps & {
+  /** Size of the viewport in which the modal is rendered */
+  viewport: string;
+};

--- a/src/components/modal/types.d.ts
+++ b/src/components/modal/types.d.ts
@@ -24,6 +24,10 @@ export interface ModalProps {
    */
   className?: string;
   /**
+   * Whether the modal's content should be scrollable if it overflows. Default to `true`.
+   */
+  scrollable?: boolean;
+  /**
    * Callback executed when the modal is dismissed by clicking on the overlay, the close button or
    * pressing the escape key
    */

--- a/src/components/modal/types.ts
+++ b/src/components/modal/types.ts
@@ -1,0 +1,35 @@
+import { ReactNode } from 'react';
+
+export interface ModalProps {
+  /**
+   * Title used by screen readers
+   */
+  title: string;
+  /**
+   * Whether the modal is opened
+   */
+  open: boolean;
+  /**
+   * Whether the user can close the modal by clicking on the overlay, the close button or pressing
+   * the escape key
+   */
+  dismissable?: boolean;
+  /**
+   * Size (width) of the modal
+   */
+  size?: 'narrow' | 'default' | 'wide';
+  children?: ReactNode;
+  /**
+   * Class name to assign to the modal
+   */
+  className?: string;
+  /**
+   * Whether the modal's content should be scrollable if it overflows. Default to `true`.
+   */
+  scrollable?: boolean;
+  /**
+   * Callback executed when the modal is dismissed by clicking on the overlay, the close button or
+   * pressing the escape key
+   */
+  onDismiss: () => void;
+}

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -7,6 +7,7 @@ import { OverlayProvider } from '@react-aria/overlays';
 import { Provider as AuthenticationProvider } from 'next-auth/client';
 import { Hydrate } from 'react-query/hydration';
 
+import { MediaContextProvider } from 'components/media-query';
 import store from 'store';
 
 import 'styles/globals.css';
@@ -25,7 +26,9 @@ const MyApp: React.FC<AppProps> = ({ Component, pageProps }: AppProps) => (
           }}
         >
           <OverlayProvider>
-            <Component {...pageProps} />
+            <MediaContextProvider>
+              <Component {...pageProps} />
+            </MediaContextProvider>
           </OverlayProvider>
         </AuthenticationProvider>
       </Hydrate>

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -2,6 +2,7 @@
 import type { DocumentContext, DocumentInitialProps } from 'next/document';
 import Document, { Html, Head, Main, NextScript } from 'next/document';
 
+import { mediaStyles } from 'components/media-query';
 import { GA_TRACKING_ID } from 'lib/analytics/ga';
 
 class MyDocument extends Document {
@@ -14,6 +15,7 @@ class MyDocument extends Document {
     return (
       <Html>
         <Head>
+          <style type="text/css" dangerouslySetInnerHTML={{ __html: mediaStyles }} />
           {/* Global site tag (gtag.js) - Google Analytics */}
           <script async src={`https://www.googletagmanager.com/gtag/js?id=${GA_TRACKING_ID}`} />
           <script

--- a/styles.config.js
+++ b/styles.config.js
@@ -1,0 +1,16 @@
+/**
+ * This file contain Tailwind CSS variables that are shared between the JS bundle and the Tailwind
+ * configuration file (tailwind.config.js). Only add here variables that you want to access from the
+ * JS/TS files.
+ *
+ * Please follow the Tailwind syntax in this file.
+ */
+module.exports = {
+  screens: {
+    sm: '640px',
+    md: '768px',
+    lg: '1024px',
+    xl: '1280px',
+    '2xl': '1536px',
+  },
+};

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,7 +1,8 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 const forms = require('@tailwindcss/forms');
 
-const lineClamp = require('./src/lib/tailwind/line-clamp');
+const lineClamp = require('./lib/tailwind/line-clamp');
+const styles = require('./styles.config');
 
 module.exports = {
   purge: {
@@ -10,6 +11,7 @@ module.exports = {
   },
   darkMode: false, // or 'media' or 'class'
   theme: {
+    ...styles,
     extend: {},
   },
   variants: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,6 +5,15 @@ __metadata:
   version: 5
   cacheKey: 8
 
+"@artsy/fresnel@npm:^3.4.0":
+  version: 3.4.0
+  resolution: "@artsy/fresnel@npm:3.4.0"
+  peerDependencies:
+    react: ">=16.3.0 <18.0.0"
+  checksum: fb215c7466c7dbb1a8217fa789029e2946bdc7aee86352ff90a9f4bfa47de4e6297717ec1af61da8093d71e56a0d34af1c3029fca99470becc36db831f7aa359
+  languageName: node
+  linkType: hard
+
 "@babel/code-frame@npm:7.12.11":
   version: 7.12.11
   resolution: "@babel/code-frame@npm:7.12.11"
@@ -10278,6 +10287,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "front-end-scaffold@workspace:."
   dependencies:
+    "@artsy/fresnel": ^3.4.0
     "@babel/core": ^7.14.2
     "@deck.gl/core": 8.4.16
     "@deck.gl/geo-layers": 8.4.16
@@ -10357,7 +10367,6 @@ __metadata:
     react-popper: ^2.2.5
     react-query: ^3.16.0
     react-redux: ^7.2.4
-    rooks: ^5.10.0
     start-server-and-test: ^1.12.1
     svg-sprite-loader: ^6.0.6
     svgo: 1.3.2
@@ -15496,15 +15505,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"raf@npm:^3.4.1":
-  version: 3.4.1
-  resolution: "raf@npm:3.4.1"
-  dependencies:
-    performance-now: ^2.1.0
-  checksum: 50ba284e481c8185dbcf45fc4618ba3aec580bb50c9121385d5698cb6012fe516d2015b1df6dd407a7b7c58d44be8086108236affbce1861edd6b44637c8cd52
-  languageName: node
-  linkType: hard
-
 "ramda@npm:^0.21.0":
   version: 0.21.0
   resolution: "ramda@npm:0.21.0"
@@ -16479,19 +16479,6 @@ __metadata:
     hash-base: ^3.0.0
     inherits: ^2.0.1
   checksum: 006accc40578ee2beae382757c4ce2908a826b27e2b079efdcd2959ee544ddf210b7b5d7d5e80467807604244e7388427330f5c6d4cd61e6edaddc5773ccc393
-  languageName: node
-  linkType: hard
-
-"rooks@npm:^5.10.0":
-  version: 5.10.0
-  resolution: "rooks@npm:5.10.0"
-  dependencies:
-    lodash.debounce: ^4.0.8
-    raf: ^3.4.1
-  peerDependencies:
-    react: ^16.8.0  || ^17.0.0
-    react-dom: ^16.8.0  || ^17.0.0
-  checksum: 67ef3402f0e2f318e02d6426b8c93500fc60d094f9fe0649b048e40c3271e5cdb2ed71806bf38df0f6378314fd8a5fe2760ad234c82a8451017e8b98b34d5d3c
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -10357,6 +10357,7 @@ __metadata:
     react-popper: ^2.2.5
     react-query: ^3.16.0
     react-redux: ^7.2.4
+    rooks: ^5.10.0
     start-server-and-test: ^1.12.1
     svg-sprite-loader: ^6.0.6
     svgo: 1.3.2
@@ -15495,6 +15496,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"raf@npm:^3.4.1":
+  version: 3.4.1
+  resolution: "raf@npm:3.4.1"
+  dependencies:
+    performance-now: ^2.1.0
+  checksum: 50ba284e481c8185dbcf45fc4618ba3aec580bb50c9121385d5698cb6012fe516d2015b1df6dd407a7b7c58d44be8086108236affbce1861edd6b44637c8cd52
+  languageName: node
+  linkType: hard
+
 "ramda@npm:^0.21.0":
   version: 0.21.0
   resolution: "ramda@npm:0.21.0"
@@ -16469,6 +16479,19 @@ __metadata:
     hash-base: ^3.0.0
     inherits: ^2.0.1
   checksum: 006accc40578ee2beae382757c4ce2908a826b27e2b079efdcd2959ee544ddf210b7b5d7d5e80467807604244e7388427330f5c6d4cd61e6edaddc5773ccc393
+  languageName: node
+  linkType: hard
+
+"rooks@npm:^5.10.0":
+  version: 5.10.0
+  resolution: "rooks@npm:5.10.0"
+  dependencies:
+    lodash.debounce: ^4.0.8
+    raf: ^3.4.1
+  peerDependencies:
+    react: ^16.8.0  || ^17.0.0
+    react-dom: ^16.8.0  || ^17.0.0
+  checksum: 67ef3402f0e2f318e02d6426b8c93500fc60d094f9fe0649b048e40c3271e5cdb2ed71806bf38df0f6378314fd8a5fe2760ad234c82a8451017e8b98b34d5d3c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR fixes a couple of issues with the modal on small screens:
1. The modal would be displayed partially off-screen on mobiles
2. The content of the modal wouldn't be scrollable by default

To fix the first issue, I've imported a hook, `useMediaMatch`, from the library [rooks](https://react-hooks.org/), which allows us to detect when a media query is matched. It is used to determine if the screen is wider than 640px, Tailwind's SM breakpoint value. If the screen is narrower than that, then the horizontal translation of the content is null, otherwise -50%.

The fix is unperfect and I would appreciate some help with someone more experienced with Framer Motion: when going from a wider screen to a smaller screen, the modal is still displayed partially off-screen. The reverse is not true. In any case, if the modal is re-opened, it is displayed correctly.

The second fix makes the content of the modal scrollable by default so that mobile users can read the full content of the modal. The change is tied to a prop, `scrollable`, that can be set to `false` in case you need advanced customisation of the modal's layout (e.g. you want buttons to always be displayed at the bottom and only the centre content to be scrollable).

## Testing instructions

1. Open Storybooks and navigate to the Modal story
2. Reduce the size of the window to the one of a mobile
3. Click the button to open the modal

The modal should look ok, and the text is scrollable if it doesn't fit by default.

4. Make the window wider

The modal should still look ok and centred correctly.