### PR TITLE
adds Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,53 @@
+# Install dependencies only when needed
+FROM node:16-alpine AS deps
+# Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
+RUN apk add --no-cache libc6-compat
+WORKDIR /app
+COPY package.json yarn.lock ./
+RUN yarn install --immutable
+
+# If using npm with a `package-lock.json` comment out above and use below instead
+# COPY package.json package-lock.json ./
+# RUN npm ci
+
+# Rebuild the source code only when needed
+FROM node:16-alpine AS builder
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+
+# Next.js collects completely anonymous telemetry data about general usage.
+# Learn more here: https://nextjs.org/telemetry
+# Uncomment the following line in case you want to disable telemetry during the build.
+# ENV NEXT_TELEMETRY_DISABLED 1
+
+RUN yarn build
+
+# Production image, copy all the files and run next
+FROM node:16-alpine AS runner
+WORKDIR /app
+
+ENV NODE_ENV production
+# Uncomment the following line in case you want to disable telemetry during runtime.
+# ENV NEXT_TELEMETRY_DISABLED 1
+
+RUN addgroup --system --gid 1001 nodejs
+RUN adduser --system --uid 1001 nextjs
+
+# You only need to copy next.config.js if you are NOT using the default configuration
+COPY --from=builder /app/next.config.js ./
+COPY --from=builder /app/public ./public
+COPY --from=builder /app/package.json ./package.json
+
+# Automatically leverage output traces to reduce image size
+# https://nextjs.org/docs/advanced-features/output-file-tracing
+COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+
+USER nextjs
+
+EXPOSE 3000
+
+ENV PORT 3000
+
+CMD ["node", "server.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ COPY . .
 # Next.js collects completely anonymous telemetry data about general usage.
 # Learn more here: https://nextjs.org/telemetry
 # Uncomment the following line in case you want to disable telemetry during the build.
-# ENV NEXT_TELEMETRY_DISABLED 1
+ENV NEXT_TELEMETRY_DISABLED 1
 
 RUN yarn build
 

--- a/next.config.js
+++ b/next.config.js
@@ -10,6 +10,10 @@ const nextConfig = {
 
     return config;
   },
+  experimental: {
+    // https://nextjs.org/docs/advanced-features/output-file-tracing#automatically-copying-traced-files-experimental
+    outputStandalone: true,
+  },
 };
 
 module.exports = withPlugins(


### PR DESCRIPTION
Context: in case the application needs to be deployed in a non-Vercel platform, we must provide, at least, an alternative for it. I suggest going with a Dockerfile. 

This PR ensures the application can be run in a dockerized container. 

To test the PR:
1) ensure you have Docker installed
2) run `docker build -t {app_name} .` to build container and images
3) run `docker run -p 3000:3000 {app_name}`

The application should be available in `http://localhost:3000/` now.

Reference: the Dockerfile is a copy of the [one provided by NextJS](https://github.com/vercel/next.js/blob/canary/examples/with-docker/Dockerfile).

This PR closes [this issue](https://github.com/Vizzuality/front-end-scaffold/issues/26).
