### PR TITLE
Fixed double yarn install in Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,8 @@
+Dockerfile
+.dockerignore
 node_modules
+npm-debug.log
+README.md
 .next
+.git
+.yarn/cache

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,9 @@
 FROM node:16.14-alpine3.15 AS deps
 # Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
 RUN apk add --no-cache libc6-compat git
-RUN corepack enable
 WORKDIR /app
-COPY package.json yarn.lock ./
-
-RUN corepack enable
+COPY .yarn ./.yarn
+COPY package.json yarn.lock .yarnrc.yml ./
 RUN yarn install --immutable
 
 # If using npm with a `package-lock.json` comment out above and use below instead
@@ -17,20 +15,13 @@ RUN yarn install --immutable
 FROM node:16.14-alpine3.15 AS builder
 WORKDIR /app
 COPY . .
-COPY --from=deps /app/.yarn ./.yarn
-COPY --from=deps /app/.pnp.cjs /app/.pnp.loader.mjs ./
-RUN corepack enable
+COPY --from=deps /app/node_modules ./node_modules
 
 # Next.js collects completely anonymous telemetry data about general usage.
 # Learn more here: https://nextjs.org/telemetry
 # Uncomment the following line in case you want to disable telemetry during the build.
 ENV NEXT_TELEMETRY_DISABLED 1
 
-# Prior to yarn 3, this 2nd call to "yarn install" would not be needed
-# However, stuff breaks without it. We do carry over the cache from the previous step,
-# so it is faster than a cold install
-# TODO: figure out how to not have to run "yarn install" a 2nd time
-RUN yarn install --immutable
 RUN yarn build
 
 # Production image, copy all the files and run next
@@ -51,7 +42,8 @@ COPY --from=builder /app/package.json ./package.json
 
 # Automatically leverage output traces to reduce image size
 # https://nextjs.org/docs/advanced-features/output-file-tracing
-COPY --from=builder --chown=nextjs:nodejs /app/.next ./
+COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
 
 USER nextjs
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+version: "3.9"  # optional since v1.27.0
+services:
+  app:
+    build: .
+    ports:
+      - "3000:3000"


### PR DESCRIPTION
A double `yarn install` is not cool
since yarn version 3 you need to add the `.yarn` folder 