### PR TITLE
updates fs fallback and standalone mode syntax

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,19 +1,21 @@
-/* eslint-disable */
 const withPlugins = require('next-compose-plugins');
 const withOptimizedImages = require('next-optimized-images');
 
-const nextConfig = {
-  webpack: (config) => {
-    config.node = {
-      fs: 'empty',
-    };
+/**
+ * @type {import('next').NextConfig}
+ */
 
+const nextConfig = {
+  // ? https://github.com/vercel/next.js/issues/7755#issuecomment-812805708
+  webpack: (config, { isServer }) => {
+    if (!isServer) {
+      config.resolve.fallback.fs = false;
+    }
     return config;
   },
-  experimental: {
-    // https://nextjs.org/docs/advanced-features/output-file-tracing#automatically-copying-traced-files-experimental
-    outputStandalone: true,
-  },
+
+  // ? https://nextjs.org/docs/advanced-features/output-file-tracing#automatically-copying-traced-files
+  output: 'standalone',
 };
 
 module.exports = withPlugins(


### PR DESCRIPTION
This PR addresses the following issues:

- updates `next@12.2.2` to close https://github.com/Vizzuality/front-end-scaffold/issues/60
- closes https://github.com/Vizzuality/front-end-scaffold/issues/61