### PR TITLE
React map gl initial view state

### DIFF
--- a/src/components/map/component.stories.tsx
+++ b/src/components/map/component.stories.tsx
@@ -93,12 +93,12 @@ const Template: Story<CustomMapProps> = (args: CustomMapProps) => {
     <div className="relative w-full h-screen">
       <Map
         id={id}
-        viewState={viewState}
-        onViewStateChange={handleViewState}
         maxZoom={maxZoom}
-        mapboxAccessToken={process.env.STORYBOOK_MAPBOX_API_TOKEN}
-        initialViewState={initialViewState}
         bounds={bounds}
+        initialViewState={initialViewState}
+        viewState={viewState}
+        mapboxAccessToken={process.env.STORYBOOK_MAPBOX_API_TOKEN}
+        onMapViewStateChange={handleViewState}
       >
         {(map) => (
           <LayerManager

--- a/src/components/map/component.stories.tsx
+++ b/src/components/map/component.stories.tsx
@@ -66,7 +66,7 @@ export default story;
 const cartoProvider = new CartoProvider();
 
 const Template: Story<CustomMapProps> = (args: CustomMapProps) => {
-  const { id, bounds, maxZoom } = args;
+  const { id, initialViewState, bounds, maxZoom } = args;
   const [viewState, setViewState] = useState<Partial<ViewState>>({});
   const { [id]: mapRef } = useMap();
 
@@ -77,6 +77,7 @@ const Template: Story<CustomMapProps> = (args: CustomMapProps) => {
   const handleFitBoundsChange = useCallback(
     (_bounds: Bounds) => {
       const { bbox, options } = _bounds;
+
       mapRef.fitBounds(
         [
           [bbox[0], bbox[1]],
@@ -96,6 +97,8 @@ const Template: Story<CustomMapProps> = (args: CustomMapProps) => {
         onViewStateChange={handleViewState}
         maxZoom={maxZoom}
         mapboxAccessToken={process.env.STORYBOOK_MAPBOX_API_TOKEN}
+        initialViewState={initialViewState}
+        bounds={bounds}
       >
         {(map) => (
           <LayerManager
@@ -124,11 +127,17 @@ Default.args = {
   id: 'map-storybook',
   className: '',
   viewport: {},
+  initialViewState: {
+    bounds: [10.5194091796875, 43.6499881760459, 10.9588623046875, 44.01257086123085],
+    fitBoundsOptions: {
+      padding: 250,
+    },
+  },
   bounds: {
     bbox: [10.5194091796875, 43.6499881760459, 10.9588623046875, 44.01257086123085],
     options: {
       padding: 250,
-      duration: 5000,
+      duration: 1000,
     },
   },
   onMapViewportChange: (viewport) => {
@@ -140,5 +149,5 @@ Default.args = {
   onMapLoad: ({ map, mapContainer }) => {
     console.info('onMapLoad: ', map, mapContainer);
   },
-  maxZoom: 4,
+  maxZoom: 20,
 };

--- a/src/components/map/component.tsx
+++ b/src/components/map/component.tsx
@@ -30,7 +30,7 @@ export const CustomMap: FC<CustomMapProps> = ({
   bounds,
   onMapReady,
   onMapLoad,
-  onViewStateChange,
+  onMapViewStateChange,
   dragPan,
   dragRotate,
   scrollZoom,
@@ -60,7 +60,7 @@ export const CustomMap: FC<CustomMapProps> = ({
    * CALLBACKS
    */
   const debouncedViewStateChange = useDebouncedCallback((_viewState: ViewState) => {
-    onViewStateChange(_viewState);
+    onMapViewStateChange(_viewState);
   }, 250);
 
   const handleLoad = useCallback(() => {

--- a/src/components/map/component.tsx
+++ b/src/components/map/component.tsx
@@ -26,6 +26,7 @@ export const CustomMap: FC<CustomMapProps> = ({
   children,
   className,
   viewState = {},
+  initialViewState,
   bounds,
   onMapReady,
   onMapLoad,
@@ -45,10 +46,12 @@ export const CustomMap: FC<CustomMapProps> = ({
   /**
    * STATE
    */
-  const [localViewState, setLocalViewState] = useState<Partial<ViewState>>({
-    ...DEFAULT_VIEW_STATE,
-    ...viewState,
-  });
+  const [localViewState, setLocalViewState] = useState<Partial<ViewState>>(
+    !initialViewState && {
+      ...DEFAULT_VIEW_STATE,
+      ...viewState,
+    }
+  );
   const [isFlying, setFlying] = useState(false);
   const [ready, setReady] = useState(false);
   const [loaded, setLoaded] = useState(false);
@@ -99,7 +102,12 @@ export const CustomMap: FC<CustomMapProps> = ({
   }, [onMapReady, mapRef]);
 
   useEffect(() => {
-    if (loaded && !isEmpty(bounds) && !!bounds.bbox && bounds.bbox.every((b) => !!b)) {
+    if (
+      loaded &&
+      !isEmpty(bounds) &&
+      !!bounds.bbox &&
+      bounds.bbox.every((b) => typeof b === 'number')
+    ) {
       handleFitBounds();
     }
   }, [loaded, bounds, handleFitBounds]);
@@ -112,7 +120,7 @@ export const CustomMap: FC<CustomMapProps> = ({
   }, [viewState]);
 
   useEffect(() => {
-    if (!bounds) return null;
+    if (!bounds) return undefined;
 
     const { options } = bounds;
     const animationDuration = (options?.duration as number) || 0;
@@ -145,15 +153,16 @@ export const CustomMap: FC<CustomMapProps> = ({
         // ! and replace with the according map styles
         mapLib={MapLibreGL}
         mapStyle="https://demotiles.maplibre.org/style.json"
-        onLoad={handleLoad}
+        initialViewState={initialViewState}
         dragPan={!isFlying && dragPan}
         dragRotate={!isFlying && dragRotate}
         scrollZoom={!isFlying && scrollZoom}
         doubleClickZoom={!isFlying && doubleClickZoom}
+        onLoad={handleLoad}
+        onMove={handleMapMove}
         {...(process.env.NODE_ENV === 'test' && { testMode: true })}
         {...mapboxProps}
         {...localViewState}
-        onMove={handleMapMove}
       >
         {ready &&
           loaded &&

--- a/src/components/map/layers.ts
+++ b/src/components/map/layers.ts
@@ -3,14 +3,13 @@ import { MapboxLayer } from '@deck.gl/mapbox';
 import GL from '@luma.gl/constants';
 import { DecodedLayer } from '@vizzuality/layer-manager-layers-deckgl';
 
-export const DECK_LAYER = [
+export const LAYERS = [
+  // DECODED RASTER LAYER
   {
-    id: 'loss',
+    id: 'loss-layer',
     type: 'deck',
     source: {
       parse: false,
-      tiles:
-        'https://storage.googleapis.com/wri-public/Hansen_16/tiles/hansen_world/v1/tc30/{z}/{x}/{y}.png',
     },
     render: {
       parse: false,
@@ -98,9 +97,6 @@ export const DECK_LAYER = [
       }),
     ],
   },
-];
-
-export const LAYERS = [
   // RASTER LAYER
   {
     id: 'gain',
@@ -108,13 +104,15 @@ export const LAYERS = [
     source: {
       type: 'raster',
       tiles: ['https://earthengine.google.org/static/hansen_2013/gain_alpha/{z}/{x}/{y}.png'],
+      minzoom: 3, // ? https://docs.mapbox.com/mapbox-gl-js/style-spec/layers/#minzoom
+      maxzoom: 12, // ? https://docs.mapbox.com/mapbox-gl-js/style-spec/layers/#maxzoom
     },
     render: {
       layers: [
         {
           type: 'raster',
-          minzoom: 2, // ? https://docs.mapbox.com/mapbox-gl-js/style-spec/layers/#minzoom
-          maxzoom: 8, // ? https://docs.mapbox.com/mapbox-gl-js/style-spec/layers/#maxzoom
+          // minzoom: 3, // ? https://docs.mapbox.com/mapbox-gl-js/style-spec/layers/#minzoom
+          // maxzoom: 12, // ? https://docs.mapbox.com/mapbox-gl-js/style-spec/layers/#maxzoom
         },
       ],
     },
@@ -225,8 +223,6 @@ export const LAYERS = [
       ],
     },
   },
-  // DECODED RASTER LAYER
-  ...DECK_LAYER,
 ];
 
 export default LAYERS;

--- a/src/components/map/types.d.ts
+++ b/src/components/map/types.d.ts
@@ -30,5 +30,5 @@ export interface CustomMapProps extends MapProps {
   onMapLoad?: ({ map, mapContainer }) => void;
 
   /** A function that exposes the viewport */
-  onViewStateChange?: (viewport: Partial<ViewState>) => void;
+  onMapViewStateChange?: (viewport: Partial<ViewState>) => void;
 }


### PR DESCRIPTION
- Map component now supports `initialViewState` if you want to set the map to some location/bounds/rotation from the beginning.
- Rename `onViewStateChange` to `onMapViewStateChange` to improve consistency
- Fix bug with [`bboxes`with a 0](https://github.com/Vizzuality/front-end-scaffold/pull/71/files#diff-93b7d949aa3db154c2bdeaf7d7e1b1c4fdca6ec8c947f72cb421424253db5380R109) in any of their values 