### PR TITLE
Fix an important security issue that leaks data (react-query)

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 import { MapProvider } from 'react-map-gl';
 import { Provider as ReduxProvider } from 'react-redux';
@@ -18,10 +18,12 @@ import store from 'store';
 
 import 'styles/globals.css';
 
-const queryClient = new QueryClient();
-
 const MyApp: React.FC<AppProps> = ({ Component, pageProps }: AppProps) => {
   const router = useRouter();
+
+  // Never ever instantiate the client outside a component, hook or callback as it can leak data
+  // between users
+  const [queryClient] = useState(() => new QueryClient());
 
   const handleRouteChangeCompleted = useCallback((url: string) => {
     GAPage(url);


### PR DESCRIPTION
When SSR is used, it is **very important** that the `QueryClient` object is not instantiated outside of a component, hook, callback, etc. otherwise the cache will be shared by all the clients (users). If the application has user accounts, data may leak between users.

Unfortunately, up until February 2021, [react-query was still recommending](https://github.com/TanStack/query/issues/1762) to do so in it's documentation.

The most likely place where the query client is instantiated outside a component is in the `pages/_app.(t|j)sx`. It can be addressed easily by caching the client using a `useState` hook. This is now [the recommended way](https://github.com/TanStack/query/blob/v3/examples/nextjs/pages/_app.js#L5-L16) to do so:
```tsx
export default function MyApp({ Component, pageProps }) {
  // The query client is instantiated *inside* the component
  const [queryClient] = React.useState(() => new QueryClient())

  // Rest of the component…
};
```

This fix works with both react-query 3 and 4.