### PR TITLE
FIX: tooltip arrow placement

### DIFF
--- a/src/components/tooltip/component.tsx
+++ b/src/components/tooltip/component.tsx
@@ -25,7 +25,7 @@ export const Tooltip = ({
   children,
   content,
   trigger = 'hover',
-  placement = 'top',
+  placement: initialPlacement = 'top',
   arrowProps = {
     enabled: false,
     size: 8,
@@ -39,8 +39,8 @@ export const Tooltip = ({
 
   const arrowRef = useRef<HTMLDivElement>(null);
 
-  const { x, y, reference, floating, strategy, context, middlewareData } = useFloating({
-    placement,
+  const { x, y, reference, floating, strategy, context, placement, middlewareData } = useFloating({
+    placement: initialPlacement,
     open,
     onOpenChange: setOpen,
     middleware: [
@@ -83,7 +83,7 @@ export const Tooltip = ({
     right: 'left',
     bottom: 'top',
     left: 'right',
-  }[placement.split('-')[0]];
+  }[placement.split('-')[0]]; // Be sure that you use the placement from the useFloating hook
 
   return (
     <>


### PR DESCRIPTION
This PR fixes a little bug when using the `Tooltip` component.
As it has a shift and flip middleware you must use the placement returned from the `useFloating` hook, because it's dynamic.

![image](https://user-images.githubusercontent.com/8928965/189643032-cf79589a-bad4-4bd4-b16e-1cf0fa2a86d6.png)

![image](https://user-images.githubusercontent.com/8928965/189642956-f8de1c4a-b4fa-461b-bb9d-7b93c69f094e.png)
