### PR TITLE
Add Tailwind Prettier plugin

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,7 +4,12 @@ module.exports = {
     es2021: true,
     node: true,
   },
-  extends: ['next/core-web-vitals', 'airbnb-typescript', 'prettier'],
+  extends: [
+    'next/core-web-vitals',
+    'airbnb-typescript',
+    'plugin:react/jsx-runtime',
+    'plugin:prettier/recommended',
+  ],
   parser: '@typescript-eslint/parser',
   parserOptions: {
     ecmaFeatures: {
@@ -14,18 +19,9 @@ module.exports = {
     sourceType: 'module',
     project: './tsconfig.eslint.json',
   },
-  plugins: ['@typescript-eslint', 'prettier'],
+  plugins: ['@typescript-eslint'],
   rules: {
     'no-console': [1, { allow: ['info', 'error'] }],
-    'prettier/prettier': [
-      'error',
-      {},
-      {
-        usePrettierrc: true,
-      },
-    ],
-    // https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html#eslint
-    'react/react-in-jsx-scope': 'off',
     // NextJs specific fix: allow jsx syntax in js and ts files
     'react/jsx-filename-extension': [1, { extensions: ['.js', '.jsx', '.ts', '.tsx'] }],
     'react/jsx-props-no-spreading': [

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,0 +1,11 @@
+const tailwindPlugin = require('prettier-plugin-tailwindcss');
+
+const config = {
+  semi: true,
+  tabWidth: 2,
+  printWidth: 100,
+  singleQuote: true,
+  plugins: [tailwindPlugin],
+};
+
+module.exports = config;

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,6 +1,0 @@
-{
-  "semi": true,
-  "tabWidth": 2,
-  "printWidth": 100,
-  "singleQuote": true
-}

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "eslint-plugin-react-hooks": "4.3.0",
     "husky": "6.0.0",
     "prettier": "2.3.0",
-    "prettier-plugin-tailwindcss": "^0.1.13",
+    "prettier-plugin-tailwindcss": "0.1.13",
     "start-server-and-test": "1.12.1",
     "storybook-addon-swc": "1.1.8",
     "svg-sprite-loader": "6.0.11",

--- a/package.json
+++ b/package.json
@@ -111,6 +111,7 @@
     "eslint-plugin-react-hooks": "4.3.0",
     "husky": "6.0.0",
     "prettier": "2.3.0",
+    "prettier-plugin-tailwindcss": "^0.1.13",
     "start-server-and-test": "1.12.1",
     "storybook-addon-swc": "1.1.8",
     "svg-sprite-loader": "6.0.11",

--- a/src/components/avatar/component.stories.tsx
+++ b/src/components/avatar/component.stories.tsx
@@ -44,7 +44,7 @@ export function Groups(): ReactNode {
       </li>
       <li className="ml-3">
         <Avatar className="bg-white">
-          <Icon icon={HELP_SVG} className="w-5 h-5" />
+          <Icon icon={HELP_SVG} className="h-5 w-5" />
         </Avatar>
       </li>
     </ul>

--- a/src/components/avatar/component.tsx
+++ b/src/components/avatar/component.tsx
@@ -7,7 +7,7 @@ import type { AvatarProps } from './types';
 export const Avatar: FC<AvatarProps> = ({ children, className, bgImage }: AvatarProps) => (
   <div
     className={cx({
-      'relative z-0 hover:z-10 flex items-center justify-center bg-transparent bg-cover bg-no-repeat bg-center border-2 border-gray-700 w-10 h-10 rounded-full':
+      'relative z-0 flex h-10 w-10 items-center justify-center rounded-full border-2 border-gray-700 bg-transparent bg-cover bg-center bg-no-repeat hover:z-10':
         true,
       [className]: !!className,
     })}

--- a/src/components/confirmation-prompt/component.tsx
+++ b/src/components/confirmation-prompt/component.tsx
@@ -28,13 +28,13 @@ export const ConfirmationPrompt: FC<ConfirmationPromptProps> = ({
     }}
   >
     <div className="px-8 py-4">
-      <div className="mt-8 text-xl font-medium text-gray-800 leading-1 sm:mt-0 sm:pr-32 font-heading">
+      <div className="leading-1 font-heading mt-8 text-xl font-medium text-gray-800 sm:mt-0 sm:pr-32">
         {title}
       </div>
       <p className="mt-4 text-sm text-gray-400 sm:pr-32">{description}</p>
       <div
         className={classnames({
-          'flex justify-start items-end': true,
+          'flex items-end justify-start': true,
           'mt-10 sm:mt-12': !icon && !description,
           'mt-8': !icon && !!description,
           'mt-10 sm:mt-1': !!icon && !description,
@@ -48,7 +48,7 @@ export const ConfirmationPrompt: FC<ConfirmationPromptProps> = ({
           Yes
         </Button>
 
-        {icon && <Icon icon={icon} className="hidden ml-auto sm:block shrink grow w-36" />}
+        {icon && <Icon icon={icon} className="ml-auto hidden w-36 shrink grow sm:block" />}
       </div>
     </div>
   </Modal>

--- a/src/components/cookies/component.tsx
+++ b/src/components/cookies/component.tsx
@@ -30,9 +30,9 @@ export const Cookies: React.FC<CookiesProps> = ({ open, onAccept, onReject }: Co
                 delay: 0,
               },
             }}
-            className="fixed bottom-0 left-0 z-50 w-full p-6 overflow-hidden transform translate-y-full bg-gray-100 outline-none"
+            className="fixed bottom-0 left-0 z-50 w-full translate-y-full transform overflow-hidden bg-gray-100 p-6 outline-none"
           >
-            <div className="flex flex-col space-y-5 lg:flex-row lg:justify-between lg:items-center lg:space-x-5 lg:space-y-0">
+            <div className="flex flex-col space-y-5 lg:flex-row lg:items-center lg:justify-between lg:space-x-5 lg:space-y-0">
               <p className="text-base">
                 This website uses cookies to ensure you get the best experience on our website. Read
                 our{' '}

--- a/src/components/forms/component.stories.tsx
+++ b/src/components/forms/component.stories.tsx
@@ -110,7 +110,7 @@ export function Form(): ReactNode {
               validate={composeValidators([booleanValidator])}
             >
               {(flprops) => (
-                <div className="flex mt-2">
+                <div className="mt-2 flex">
                   <Checkbox id="form-checkbox" {...flprops} />
                   <Label htmlFor="form-checkbox" className="ml-2">
                     This is a standalone checkbox
@@ -130,7 +130,7 @@ export function Form(): ReactNode {
               validate={composeValidators([arrayValidator])}
             >
               {(flprops) => (
-                <div className="flex mt-2">
+                <div className="mt-2 flex">
                   <Checkbox id="form-checkbox-group-1" {...flprops} />
                   <Label htmlFor="form-checkbox-group-1" className="ml-2">
                     Option 1
@@ -146,7 +146,7 @@ export function Form(): ReactNode {
               validate={composeValidators([arrayValidator])}
             >
               {(flprops) => (
-                <div className="flex mt-2">
+                <div className="mt-2 flex">
                   <Checkbox id="form-checkbox-group-2" {...flprops} />
                   <Label htmlFor="form-checkbox-group-2" className="ml-2">
                     Option 2
@@ -162,7 +162,7 @@ export function Form(): ReactNode {
               validate={composeValidators([arrayValidator])}
             >
               {(flprops) => (
-                <div className="flex mt-2">
+                <div className="mt-2 flex">
                   <Checkbox id="form-checkbox-group-3" {...flprops} />
                   <Label htmlFor="form-checkbox-group-3" className="ml-2">
                     Option 3
@@ -182,7 +182,7 @@ export function Form(): ReactNode {
               validate={composeValidators([{ presence: true }])}
             >
               {(flprops) => (
-                <div className="flex mt-2">
+                <div className="mt-2 flex">
                   <Radio id="radio-group-option-1" {...flprops} />
                   <Label htmlFor="radio-group-option-1" className="ml-2">
                     Option 1
@@ -198,7 +198,7 @@ export function Form(): ReactNode {
               validate={composeValidators([{ presence: true }])}
             >
               {(flprops) => (
-                <div className="flex mt-2">
+                <div className="mt-2 flex">
                   <Radio id="radio-group-option-2" {...flprops} />
                   <Label htmlFor="radio-group-option-2" className="ml-2">
                     Option 2
@@ -214,7 +214,7 @@ export function Form(): ReactNode {
               validate={composeValidators([{ presence: true }])}
             >
               {(flprops) => (
-                <div className="flex mt-2">
+                <div className="mt-2 flex">
                   <Radio id="radio-group-option-3" {...flprops} />
                   <Label htmlFor="radio-group-option-3" className="ml-2">
                     Option 3

--- a/src/components/forms/input/component.tsx
+++ b/src/components/forms/input/component.tsx
@@ -28,7 +28,7 @@ export const Input: FC<InputProps> = ({
         <Icon
           icon={icon}
           className={cx({
-            'absolute w-4 h-4 transform -translate-y-1/2 top-1/2 left-3': true,
+            'absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 transform': true,
             [THEME[theme].icon]: true,
           })}
         />

--- a/src/components/forms/select/menu/component.tsx
+++ b/src/components/forms/select/menu/component.tsx
@@ -14,7 +14,7 @@ export const SelectMenu: FC<SelectMenuProps> = ({
   <div
     className={cx({
       'overflow-hidden': true,
-      'invisible pointer-events-none': attributes?.popper?.['data-popper-reference-hidden'],
+      'pointer-events-none invisible': attributes?.popper?.['data-popper-reference-hidden'],
       [THEME[theme].open]: opened,
     })}
   >

--- a/src/components/forms/select/multi/component.tsx
+++ b/src/components/forms/select/multi/component.tsx
@@ -198,7 +198,7 @@ export const MultiSelect: FC<SelectProps> = ({
   return (
     <div
       className={cx({
-        'w-full leading-tight overflow-hidden': true,
+        'w-full overflow-hidden leading-tight': true,
         [THEME[theme].container]: true,
         [THEME[theme].closed]: true,
         [THEME.states[status]]: true,
@@ -261,7 +261,7 @@ export const MultiSelect: FC<SelectProps> = ({
             <ul
               {...getMenuProps({ onFocus, onBlur })}
               className={cx({
-                'py-1 overflow-y-auto overflow-x-hidden': true,
+                'overflow-y-auto overflow-x-hidden py-1': true,
               })}
               style={{
                 maxHeight,
@@ -270,7 +270,7 @@ export const MultiSelect: FC<SelectProps> = ({
               {getOptions.map((option, index) => (
                 <li
                   className={cx({
-                    'px-4 py-1 mt-0.5 cursor-pointer relative': true,
+                    'relative mt-0.5 cursor-pointer px-4 py-1': true,
                     [THEME[theme].item.base]: highlightedIndex !== index,
                     [THEME[theme].item.disabled]: option.disabled,
                     [THEME[theme].item.highlighted]:
@@ -290,7 +290,7 @@ export const MultiSelect: FC<SelectProps> = ({
 
                   {option.checkbox && (
                     <Checkbox
-                      className="absolute bg-opacity-0 left-4 top-1.5"
+                      className="absolute left-4 top-1.5 bg-opacity-0"
                       checked={isSelected(option, selectedItems)}
                       disabled={option.disabled}
                       onChange={() => null}

--- a/src/components/forms/select/single/component.tsx
+++ b/src/components/forms/select/single/component.tsx
@@ -151,7 +151,7 @@ export const SingleSelect: FC<SelectProps> = ({
   return (
     <div
       className={cx({
-        'w-full leading-tight overflow-hidden': true,
+        'w-full overflow-hidden leading-tight': true,
         [THEME[theme].container]: true,
         [THEME[theme].closed]: true,
         [THEME.states[status]]: true,
@@ -209,7 +209,7 @@ export const SingleSelect: FC<SelectProps> = ({
             <ul
               {...getMenuProps({ onFocus, onBlur })}
               className={cx({
-                'py-1 overflow-y-auto overflow-x-hidden': true,
+                'overflow-y-auto overflow-x-hidden py-1': true,
               })}
               style={{
                 maxHeight,
@@ -218,7 +218,7 @@ export const SingleSelect: FC<SelectProps> = ({
               {getOptions.map((option, index) => (
                 <li
                   className={cx({
-                    'px-4 py-1 mt-0.5 cursor-pointer': true,
+                    'mt-0.5 cursor-pointer px-4 py-1': true,
                     [THEME[theme].item.base]: highlightedIndex !== index,
                     [THEME[theme].item.disabled]: option.disabled,
                     [THEME[theme].item.highlighted]:

--- a/src/components/forms/select/toggle/component.tsx
+++ b/src/components/forms/select/toggle/component.tsx
@@ -39,7 +39,7 @@ export const SelectToggle: FC<SelectToggleProps> = ({
       aria-label="Select..."
       disabled={disabled}
       className={cx({
-        'relative w-full flex items-center tracking-wide': true,
+        'relative flex w-full items-center tracking-wide': true,
         [THEME.sizes[size]]: true,
       })}
       {...(!multiple && getToggleButtonProps())}
@@ -48,7 +48,7 @@ export const SelectToggle: FC<SelectToggleProps> = ({
       {prefix && (
         <span
           className={cx({
-            'mr-2 text-xs font-heading': true,
+            'font-heading mr-2 text-xs': true,
             [THEME[theme].prefix.base]: true,
           })}
         >
@@ -67,7 +67,7 @@ export const SelectToggle: FC<SelectToggleProps> = ({
 
       <Icon
         className={cx({
-          'absolute w-3 h-3 right-4': true,
+          'absolute right-4 h-3 w-3': true,
           [THEME[theme].icon.closed]: !opened,
           [THEME[theme].icon.open]: opened,
           [THEME[theme].icon.disabled]: disabled,

--- a/src/components/forms/slider/component.tsx
+++ b/src/components/forms/slider/component.tsx
@@ -105,7 +105,7 @@ export const Slider: FC<SliderProps> = ({
         'opacity-30': st === 'disabled',
       })}
     >
-      <div {...trackProps} ref={trackRef} className="relative flex items-center w-full h-full">
+      <div {...trackProps} ref={trackRef} className="relative flex h-full w-full items-center">
         <output
           {...outputProps}
           className={THEME[theme].output}

--- a/src/components/map/component.stories.tsx
+++ b/src/components/map/component.stories.tsx
@@ -90,7 +90,7 @@ const Template: Story<CustomMapProps> = (args: CustomMapProps) => {
   );
 
   return (
-    <div className="relative w-full h-screen">
+    <div className="relative h-screen w-full">
       <Map
         id={id}
         maxZoom={maxZoom}

--- a/src/components/map/component.tsx
+++ b/src/components/map/component.tsx
@@ -143,7 +143,7 @@ export const CustomMap: FC<CustomMapProps> = ({
     <div
       ref={mapContainerRef}
       className={cx({
-        'relative w-full h-full z-0': true,
+        'relative z-0 h-full w-full': true,
         [className]: !!className,
       })}
     >

--- a/src/components/map/controls/fit-bounds/component.tsx
+++ b/src/components/map/controls/fit-bounds/component.tsx
@@ -21,9 +21,9 @@ export const FitBoundsControl: FC<FitBoundsControlProps> = ({
     <button
       aria-label="Fit to bounds"
       className={cx({
-        'mb-0.5 px-0.5 py-1 rounded-3xl text-white bg-black': true,
+        'mb-0.5 rounded-3xl bg-black px-0.5 py-1 text-white': true,
         'hover:bg-gray-700 active:bg-gray-600': !!bounds,
-        'opacity-50 cursor-default': !bounds,
+        'cursor-default opacity-50': !bounds,
         [className]: !!className,
       })}
       type="button"

--- a/src/components/map/controls/zoom/component.tsx
+++ b/src/components/map/controls/zoom/component.tsx
@@ -47,9 +47,9 @@ export const ZoomControl: FC<ZoomControlProps> = ({ mapRef, className }: ZoomCon
     >
       <button
         className={cx({
-          'mb-0.5 p-0.5 rounded-t-3xl text-white bg-black': true,
+          'mb-0.5 rounded-t-3xl bg-black p-0.5 text-white': true,
           'hover:bg-gray-700 active:bg-gray-600': zoom !== maxZoom,
-          'opacity-50 cursor-default': zoom === maxZoom,
+          'cursor-default opacity-50': zoom === maxZoom,
         })}
         aria-label="Zoom in"
         type="button"
@@ -60,9 +60,9 @@ export const ZoomControl: FC<ZoomControlProps> = ({ mapRef, className }: ZoomCon
       </button>
       <button
         className={cx({
-          'p-0.5 rounded-b-3xl text-white bg-black': true,
+          'rounded-b-3xl bg-black p-0.5 text-white': true,
           'hover:bg-gray-700 active:bg-gray-600': zoom !== minZoom,
-          'opacity-50 cursor-default': zoom === minZoom,
+          'cursor-default opacity-50': zoom === minZoom,
         })}
         aria-label="Zoom out"
         type="button"

--- a/src/components/map/legend/component.tsx
+++ b/src/components/map/legend/component.tsx
@@ -29,7 +29,7 @@ export const Legend: FC<LegendProps> = ({
   return (
     <div
       className={cx({
-        'bg-black rounded-3xl flex flex-col grow': true,
+        'flex grow flex-col rounded-3xl bg-black': true,
         [className]: !!className,
       })}
     >
@@ -37,16 +37,16 @@ export const Legend: FC<LegendProps> = ({
         type="button"
         aria-expanded={active}
         aria-controls={id}
-        className="relative flex items-center w-full px-5 py-3 space-x-2 text-xs text-white uppercase font-heading"
+        className="font-heading relative flex w-full items-center space-x-2 px-5 py-3 text-xs uppercase text-white"
         onClick={onToggleActive}
       >
-        <Icon icon={LEGEND_SVG} className="w-4 h-4 text-gray-300" />
+        <Icon icon={LEGEND_SVG} className="h-4 w-4 text-gray-300" />
         <span>Legend</span>
 
         <Icon
           icon={ARROW_DOWN_SVG}
           className={cx({
-            'absolute w-3 h-3 transition-transform transform -translate-y-1/2 text-blue-500 top-1/2 right-5':
+            'absolute top-1/2 right-5 h-3 w-3 -translate-y-1/2 transform text-blue-500 transition-transform':
               true,
             'rotate-180': active,
           })}
@@ -55,16 +55,16 @@ export const Legend: FC<LegendProps> = ({
 
       {active && (
         <div
-          className="relative flex flex-col grow overflow-hidden rounded-3xl"
+          className="relative flex grow flex-col overflow-hidden rounded-3xl"
           style={{
             maxHeight,
           }}
         >
-          <div className="absolute top-0 left-0 z-10 w-full h-4 pointer-events-none bg-gradient-to-b from-black via-black" />
-          <div className="overflow-x-hidden overflow-y-auto">
+          <div className="pointer-events-none absolute top-0 left-0 z-10 h-4 w-full bg-gradient-to-b from-black via-black" />
+          <div className="overflow-y-auto overflow-x-hidden">
             <SortableList onChangeOrder={onChangeOrder}>{children}</SortableList>
           </div>
-          <div className="absolute bottom-0 left-0 z-10 w-full h-3 pointer-events-none bg-gradient-to-t from-black via-black" />
+          <div className="pointer-events-none absolute bottom-0 left-0 z-10 h-3 w-full bg-gradient-to-t from-black via-black" />
         </div>
       )}
     </div>

--- a/src/components/map/legend/item/component.tsx
+++ b/src/components/map/legend/item/component.tsx
@@ -20,7 +20,7 @@ export const LegendItem: FC<LegendItemProps> = ({
         })}
       >
         {icon && <div className="absolute top-0 left-0">{icon}</div>}
-        <div className="text-sm text-white font-heading">{name}</div>
+        <div className="font-heading text-sm text-white">{name}</div>
       </div>
     </div>
 

--- a/src/components/map/legend/mock.tsx
+++ b/src/components/map/legend/mock.tsx
@@ -6,21 +6,21 @@ const ITEMS = [
   {
     id: 'XXX',
     name: 'Included areas',
-    icon: <Icon icon={HEXAGON_SVG} className="w-3.5 h-3.5 mt-1 text-purple-500" />,
+    icon: <Icon icon={HEXAGON_SVG} className="mt-1 h-3.5 w-3.5 text-purple-500" />,
     description:
       'Lorem ipsum dolor sit amet consectetur adipisicing elit. Natus minus eligendi doloremque unde, atque maxime dolore officiis quia architecto fugiat, dolorem animi vel! Velit minus facere maxime consequuntur iure. Nisi!',
   },
   {
     id: 'YYY',
     name: 'All features',
-    icon: <div className="w-3 h-3 mt-1 bg-blue-500 rounded" />,
+    icon: <div className="mt-1 h-3 w-3 rounded bg-blue-500" />,
     description:
       'Lorem ipsum dolor sit amet consectetur adipisicing elit. Natus minus eligendi doloremque unde, atque maxime.',
   },
   {
     id: 'ZZZ',
     name: 'Protected areas',
-    icon: <div className="w-3 h-3 mt-1 bg-pink-500 rounded" />,
+    icon: <div className="mt-1 h-3 w-3 rounded bg-pink-500" />,
     description: 'Lorem ipsum dolor sit amet consectetur adipisicing elit.',
   },
   {

--- a/src/components/map/legend/types/basic/component.tsx
+++ b/src/components/map/legend/types/basic/component.tsx
@@ -13,11 +13,11 @@ export const LegendTypeBasic: FC<LegendTypeBasicProps> = ({
       [className]: !!className,
     })}
   >
-    <ul className="flex flex-col w-full space-y-1">
+    <ul className="flex w-full flex-col space-y-1">
       {items.map(({ value, color }) => (
         <li key={`${value}`} className="flex space-x-2 text-xs">
           <div
-            className="shrink-0 w-3 h-3 mt-0.5 rounded"
+            className="mt-0.5 h-3 w-3 shrink-0 rounded"
             style={{
               backgroundColor: color,
             }}

--- a/src/components/map/legend/types/choropleth/component.tsx
+++ b/src/components/map/legend/types/choropleth/component.tsx
@@ -17,7 +17,7 @@ export const LegendTypeChoropleth: FC<LegendTypeChoroplethProps> = ({
       {items.map(({ color }) => (
         <li
           key={`${color}`}
-          className="shrink-0 h-2"
+          className="h-2 shrink-0"
           style={{
             width: `${100 / items.length}%`,
             backgroundColor: color,
@@ -26,11 +26,11 @@ export const LegendTypeChoropleth: FC<LegendTypeChoroplethProps> = ({
       ))}
     </ul>
 
-    <ul className="flex w-full mt-1">
+    <ul className="mt-1 flex w-full">
       {items.map(({ value }) => (
         <li
           key={`${value}`}
-          className="shrink-0 text-xs text-center"
+          className="shrink-0 text-center text-xs"
           style={{
             width: `${100 / items.length}%`,
           }}

--- a/src/components/map/legend/types/gradient/component.tsx
+++ b/src/components/map/legend/types/gradient/component.tsx
@@ -14,13 +14,13 @@ export const LegendTypeGradient: FC<LegendTypeGradientProps> = ({
     })}
   >
     <div
-      className="flex w-full h-2"
+      className="flex h-2 w-full"
       style={{
         backgroundImage: `linear-gradient(to right, ${items.map((i) => i.color).join(',')})`,
       }}
     />
 
-    <ul className="flex justify-between w-full mt-1">
+    <ul className="mt-1 flex w-full justify-between">
       {items
         .filter(({ value }) => !!value)
         .map(({ value }) => (

--- a/src/components/modal/component.stories.tsx
+++ b/src/components/modal/component.stories.tsx
@@ -156,9 +156,9 @@ const Template: Story<ModalProps> = ({ ...args }: ModalProps) => {
               setOpenScrollable(o);
             }}
           >
-            <div className="flex flex-col py-10 space-y-5 overflow-auto grow">
+            <div className="flex grow flex-col space-y-5 overflow-auto py-10">
               <h1 className="px-10 text-xl font-medium">Modal content</h1>
-              <div className="px-10 grow">
+              <div className="grow px-10">
                 <p>
                   Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean at sodales est, eu
                   imperdiet elit. Suspendisse eget diam accumsan, lacinia odio nec, fringilla ex.
@@ -265,12 +265,12 @@ const Template: Story<ModalProps> = ({ ...args }: ModalProps) => {
               setOpenScrollable2(o);
             }}
           >
-            <div className="flex flex-col py-10 overflow-hidden grow">
+            <div className="flex grow flex-col overflow-hidden py-10">
               <h1 className="px-10 text-xl font-medium">Modal content</h1>
-              <div className="relative flex flex-col py-px overflow-hidden grow">
-                <div className="absolute left-0 z-10 w-full h-5 pointer-events-none -top-1 bg-gradient-to-b from-white via-white" />
-                <div className="relative flex flex-col overflow-hidden grow">
-                  <div className="flex flex-col px-10 py-5 overflow-x-hidden overflow-y-auto grow">
+              <div className="relative flex grow flex-col overflow-hidden py-px">
+                <div className="pointer-events-none absolute left-0 -top-1 z-10 h-5 w-full bg-gradient-to-b from-white via-white" />
+                <div className="relative flex grow flex-col overflow-hidden">
+                  <div className="flex grow flex-col overflow-y-auto overflow-x-hidden px-10 py-5">
                     <p>
                       Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean at sodales
                       est, eu imperdiet elit. Suspendisse eget diam accumsan, lacinia odio nec,
@@ -378,7 +378,7 @@ const Template: Story<ModalProps> = ({ ...args }: ModalProps) => {
                     </p>
                   </div>
                 </div>
-                <div className="absolute bottom-0 left-0 z-10 w-full h-5 pointer-events-none bg-gradient-to-t from-white via-white" />
+                <div className="pointer-events-none absolute bottom-0 left-0 z-10 h-5 w-full bg-gradient-to-t from-white via-white" />
               </div>
             </div>
           </Modal>

--- a/src/components/modal/component.tsx
+++ b/src/components/modal/component.tsx
@@ -57,7 +57,7 @@ export const Modal = (props: ModalProps) => {
                 <>
                   <Media
                     lessThan="sm"
-                    className="absolute flex flex-col w-full h-full pointer-events-none grow"
+                    className="pointer-events-none absolute flex h-full w-full grow flex-col"
                   >
                     <ModalContent
                       {...props}
@@ -67,7 +67,7 @@ export const Modal = (props: ModalProps) => {
                   </Media>
                   <Media
                     greaterThanOrEqual="sm"
-                    className="absolute flex flex-col w-full h-full pointer-events-none grow"
+                    className="pointer-events-none absolute flex h-full w-full grow flex-col"
                   >
                     <ModalContent
                       {...props}

--- a/src/components/modal/content/component.tsx
+++ b/src/components/modal/content/component.tsx
@@ -55,15 +55,15 @@ export const ModalContent: FC<ModalContentProps> = ({
         ref: floating,
       })}
     >
-      <div className="relative flex flex-col overflow-hidden grow">
+      <div className="relative flex grow flex-col overflow-hidden">
         <button
           type="button"
           onClick={() => {
             onOpenChange(false);
           }}
-          className="absolute flex items-center px-4 py-4 text-sm text-gray-300 top-6 right-6"
+          className="absolute top-6 right-6 flex items-center px-4 py-4 text-sm text-gray-300"
         >
-          <Icon icon={CLOSE_SVG} className="inline-block w-3 h-3 text-black" />
+          <Icon icon={CLOSE_SVG} className="inline-block h-3 w-3 text-black" />
         </button>
 
         {children}

--- a/src/components/search/component.tsx
+++ b/src/components/search/component.tsx
@@ -29,7 +29,7 @@ export const Search: FC<SearchProps> = ({
 
   return (
     <div
-      className={cx('flex w-full relative border-b border-gray-400', {
+      className={cx('relative flex w-full border-b border-gray-400', {
         [THEME[theme]]: true,
         [SIZES[size]]: true,
       })}
@@ -37,7 +37,7 @@ export const Search: FC<SearchProps> = ({
       <Icon
         icon={SEARCH_SVG}
         className={cx({
-          'absolute top-1/2 left-3 w-5 h-5 transform -translate-y-1/2': true,
+          'absolute top-1/2 left-3 h-5 w-5 -translate-y-1/2 transform': true,
           [THEME[theme]]: true,
         })}
       />
@@ -48,7 +48,7 @@ export const Search: FC<SearchProps> = ({
         placeholder={placeholder}
         type="search"
         className={cx(
-          'w-full font-sans px-10 bg-transparent truncate leading-4 placeholder-gray-300 placeholder-opacity-50',
+          'w-full truncate bg-transparent px-10 font-sans leading-4 placeholder-gray-300 placeholder-opacity-50',
           {
             [THEME[theme]]: true,
             [SIZES[size]]: true,
@@ -60,10 +60,10 @@ export const Search: FC<SearchProps> = ({
         <button
           {...buttonProps}
           tabIndex={0}
-          className="absolute z-10 flex items-center self-center justify-center w-5 h-5 right-3 r-2"
+          className="r-2 absolute right-3 z-10 flex h-5 w-5 items-center justify-center self-center"
           type="button"
         >
-          <Icon icon={CLOSE_SVG} className="inline-block w-2 h-2" />
+          <Icon icon={CLOSE_SVG} className="inline-block h-2 w-2" />
         </button>
       )}
     </div>

--- a/src/components/tag/component.tsx
+++ b/src/components/tag/component.tsx
@@ -9,12 +9,12 @@ export const Tag: FC<TagProps> = ({ children, className }: TagProps) => (
     className={cx({
       'relative inline-flex rounded': true,
       [`${className}`]: !!className,
-      'text-black bg-gray-200': !className,
+      'bg-gray-200 text-black': !className,
     })}
   >
     <div
       className={cx({
-        'flex-col leading-none text-sm px-2 py-1': true,
+        'flex-col px-2 py-1 text-sm leading-none': true,
       })}
     >
       <div className="flex-1">{children}</div>

--- a/src/components/toast/component.tsx
+++ b/src/components/toast/component.tsx
@@ -61,11 +61,11 @@ export const Toast: React.FC<ToastProps> = ({
       <div
         role="alert"
         className={cx({
-          'w-full pointer-events-auto mb-2': true,
+          'pointer-events-auto mb-2 w-full': true,
         })}
       >
         <div
-          className="flex w-full p-2 text-gray-500 transition bg-white shadow-md rounded-2xl hover:ring-white hover:ring-4 hover:ring-opacity-40"
+          className="flex w-full rounded-2xl bg-white p-2 text-gray-500 shadow-md transition hover:ring-4 hover:ring-white hover:ring-opacity-40"
           onMouseEnter={() => {
             controls.stop();
           }}
@@ -79,19 +79,19 @@ export const Toast: React.FC<ToastProps> = ({
           <div className="flex grow">
             <div
               className={cx({
-                'relative w-10 h-10 rounded-xl shrink-0 flex items-center justify-center shadow-md overflow-hidden z-20':
+                'relative z-20 flex h-10 w-10 shrink-0 items-center justify-center overflow-hidden rounded-xl shadow-md':
                   true,
               })}
             >
               <div
                 className={cx({
-                  'absolute top-0 left-0 z-0 w-full h-full bg-gradient-to-b': true,
+                  'absolute top-0 left-0 z-0 h-full w-full bg-gradient-to-b': true,
                   [THEME[level]?.hoverBg]: true,
                 })}
               />
               <motion.div
                 className={cx({
-                  'absolute top-0 left-0 z-10 w-full h-full bg-gradient-to-b': true,
+                  'absolute top-0 left-0 z-10 h-full w-full bg-gradient-to-b': true,
                   [THEME[level]?.bg]: true,
                 })}
                 initial={{ y: '0%' }}
@@ -100,18 +100,18 @@ export const Toast: React.FC<ToastProps> = ({
                 onAnimationComplete={handleDismiss}
               />
 
-              <Icon icon={ICON} className="relative z-20 self-center w-5 h-5" />
+              <Icon icon={ICON} className="relative z-20 h-5 w-5 self-center" />
             </div>
 
-            <div className="grow ml-2.5">{content}</div>
+            <div className="ml-2.5 grow">{content}</div>
           </div>
 
           <button
             type="button"
-            className="flex items-center justify-center w-10 h-10 ml-5 shrink-0"
+            className="ml-5 flex h-10 w-10 shrink-0 items-center justify-center"
             onClick={handleDismiss}
           >
-            <Icon icon={CLOSE_SVG} className="w-3 h-3" />
+            <Icon icon={CLOSE_SVG} className="h-3 w-3" />
           </button>
         </div>
       </div>

--- a/src/components/tooltip/component.stories.tsx
+++ b/src/components/tooltip/component.stories.tsx
@@ -12,12 +12,12 @@ const StoryTooltip = {
 export default StoryTooltip;
 
 const Template: Story<TooltipProps> = (args: TooltipProps) => (
-  <div className="text-white mt-52">
+  <div className="mt-52 text-white">
     Lorem ipsum dolor sit amet, consectetur adipisicing elit. Odit{' '}
     <Tooltip
       {...args}
       content={
-        <div className="px-2 py-1 text-gray-500 bg-white rounded">
+        <div className="rounded bg-white px-2 py-1 text-gray-500">
           <span>Tooltip</span>
         </div>
       }
@@ -30,7 +30,7 @@ const Template: Story<TooltipProps> = (args: TooltipProps) => (
       placement="bottom-end"
       trigger="click"
       content={
-        <div className="p-5 text-gray-500 bg-white rounded">
+        <div className="rounded bg-white p-5 text-gray-500">
           <h2 className="text-lg text-blue-500">Title</h2>
           <p>This is a content. We could have whateveryouwant</p>
         </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -10546,7 +10546,7 @@ __metadata:
     popmotion: 9.3.6
     postcss: 8.4.13
     prettier: 2.3.0
-    prettier-plugin-tailwindcss: ^0.1.13
+    prettier-plugin-tailwindcss: 0.1.13
     react: 18.2.0
     react-aria: 3.6.0
     react-dom: 18.2.0
@@ -15264,7 +15264,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prettier-plugin-tailwindcss@npm:^0.1.13":
+"prettier-plugin-tailwindcss@npm:0.1.13":
   version: 0.1.13
   resolution: "prettier-plugin-tailwindcss@npm:0.1.13"
   peerDependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -10546,6 +10546,7 @@ __metadata:
     popmotion: 9.3.6
     postcss: 8.4.13
     prettier: 2.3.0
+    prettier-plugin-tailwindcss: ^0.1.13
     react: 18.2.0
     react-aria: 3.6.0
     react-dom: 18.2.0
@@ -15260,6 +15261,15 @@ __metadata:
   dependencies:
     fast-diff: ^1.1.2
   checksum: 00ce8011cf6430158d27f9c92cfea0a7699405633f7f1d4a45f07e21bf78e99895911cbcdc3853db3a824201a7c745bd49bfea8abd5fb9883e765a90f74f8392
+  languageName: node
+  linkType: hard
+
+"prettier-plugin-tailwindcss@npm:^0.1.13":
+  version: 0.1.13
+  resolution: "prettier-plugin-tailwindcss@npm:0.1.13"
+  peerDependencies:
+    prettier: ">=2.2.0"
+  checksum: 1b9000686e661be81de7d36d514c5ee34a98b11639b538bce8dd3a482c073c0148feb9d54b526babaede681d1c5ecb318ad97f38e8d71dd5cc26c33dfcaf8344
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
We talked in the past about making the Headwind extension mandatory to sort Tailwind classnames in a standard way. This plugin achieves that at formatter level :)

While at it, I took the liberty of cleaning up the ESLint config file (basically, extending from some configs instead of manually defining those rules).

The whole project was linted with this new plugin, but the relevant files are only `.eslintrc.js` and the prettier config, now in shiny new JS format (`.prettierrc.js`).

I thought about changing more things. For example, the whole project is linted on commit instead of the staged files. But I want to keep the PR as small as possible.