### PR TITLE
fix: remove popmotion dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,6 @@
     "next-auth": "4.3.4",
     "next-compose-plugins": "2.2.1",
     "next-optimized-images": "2.6.2",
-    "popmotion": "9.3.6",
     "postcss": "8.4.13",
     "react": "18.2.0",
     "react-aria": "3.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10503,15 +10503,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"framesync@npm:5.3.0":
-  version: 5.3.0
-  resolution: "framesync@npm:5.3.0"
-  dependencies:
-    tslib: ^2.1.0
-  checksum: 9ebbb2863e6a1cfd2e9dd1b73af427d23caa03c92dd49ea767ebdd208c3a573bba4a1026f67068d856a21704f79adcdf2f750cc852ff73bc1f0e80edaaecded8
-  languageName: node
-  linkType: hard
-
 "framesync@npm:6.0.1":
   version: 6.0.1
   resolution: "framesync@npm:6.0.1"
@@ -10616,7 +10607,6 @@ __metadata:
     next-auth: 4.3.4
     next-compose-plugins: 2.2.1
     next-optimized-images: 2.6.2
-    popmotion: 9.3.6
     postcss: 8.4.13
     prettier: 2.3.0
     react: 18.2.0
@@ -14977,18 +14967,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"popmotion@npm:9.3.6":
-  version: 9.3.6
-  resolution: "popmotion@npm:9.3.6"
-  dependencies:
-    framesync: 5.3.0
-    hey-listen: ^1.0.8
-    style-value-types: 4.1.4
-    tslib: ^2.1.0
-  checksum: 551446ec3763790efde7a3bb8c43189122f9b559985be2efa79842138257c4e331efcff606732a4bd5ac82d9bde1b236258d69a435f4bb5e9fc5908241b5ba3f
-  languageName: node
-  linkType: hard
-
 "posix-character-classes@npm:^0.1.0":
   version: 0.1.1
   resolution: "posix-character-classes@npm:0.1.1"
@@ -17353,16 +17331,6 @@ __metadata:
   dependencies:
     inline-style-parser: 0.1.1
   checksum: 4d7084015207f2a606dfc10c29cb5ba569f2fe8005551df7396110dd694d6ff650f2debafa95bd5d147dfb4ca50f57868e2a7f91bf5d11ef734fe7ccbd7abf59
-  languageName: node
-  linkType: hard
-
-"style-value-types@npm:4.1.4":
-  version: 4.1.4
-  resolution: "style-value-types@npm:4.1.4"
-  dependencies:
-    hey-listen: ^1.0.8
-    tslib: ^2.1.0
-  checksum: 96189770076a2717bf579f7d73a49953f0c3d633b90fed9b44b8285cbbe7facd19d6d7a0d2802fb493b45995791f62b87983c3d3c24128818a69e593b6d77aed
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Remove dependency as we are not using it anymore.

[Issue #89](https://github.com/Vizzuality/front-end-scaffold/issues/89)