### PR TITLE
updates gitignore .env declaration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,10 +28,8 @@ yarn-debug.log*
 yarn-error.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*
+!.env.default
 
 # vercel
 .vercel


### PR DESCRIPTION
This PR updates the `gitignore` declaration for `.env` files to cover any possible case without hardcoding it (including `.env` itself). The only exception is `.env.default`, used as a template and keep it as part of the code.

Closes https://github.com/Vizzuality/front-end-scaffold/issues/104