### PR TITLE
updates zoom/fit bounds controls to use own map reference

### DIFF
--- a/src/components/map/component.stories.tsx
+++ b/src/components/map/component.stories.tsx
@@ -115,7 +115,7 @@ const Template: Story<CustomMapProps> = (args: CustomMapProps) => {
         )}
       </Map>
       <Controls>
-        <ZoomControl mapRef={mapRef} />
+        <ZoomControl mapId={id} />
         <FitBoundsControl bounds={bounds} onFitBoundsChange={handleFitBoundsChange} />
       </Controls>
     </div>
@@ -132,6 +132,8 @@ Default.args = {
     fitBoundsOptions: {
       padding: 250,
     },
+    maxZoom: 7,
+    minZoom: 4,
   },
   bounds: {
     bbox: [10.5194091796875, 43.6499881760459, 10.9588623046875, 44.01257086123085],

--- a/src/components/map/component.stories.tsx
+++ b/src/components/map/component.stories.tsx
@@ -92,7 +92,6 @@ const Template: Story<CustomMapProps> = (args: CustomMapProps) => {
   return (
     <div className="relative h-screen w-full">
       <Map
-        id={id}
         maxZoom={maxZoom}
         bounds={bounds}
         initialViewState={initialViewState}
@@ -101,23 +100,25 @@ const Template: Story<CustomMapProps> = (args: CustomMapProps) => {
         onMapViewStateChange={handleViewState}
       >
         {(map) => (
-          <LayerManager
-            map={map}
-            plugin={PluginMapboxGl}
-            providers={{
-              [cartoProvider.name]: cartoProvider.handleData,
-            }}
-          >
-            {LAYERS.map((l) => (
-              <Layer key={l.id} {...l} />
-            ))}
-          </LayerManager>
+          <>
+            <LayerManager
+              map={map}
+              plugin={PluginMapboxGl}
+              providers={{
+                [cartoProvider.name]: cartoProvider.handleData,
+              }}
+            >
+              {LAYERS.map((l) => (
+                <Layer key={l.id} {...l} />
+              ))}
+            </LayerManager>
+            <Controls>
+              <ZoomControl />
+              <FitBoundsControl bounds={bounds} onFitBoundsChange={handleFitBoundsChange} />
+            </Controls>
+          </>
         )}
       </Map>
-      <Controls>
-        <ZoomControl mapId={id} />
-        <FitBoundsControl bounds={bounds} onFitBoundsChange={handleFitBoundsChange} />
-      </Controls>
     </div>
   );
 };

--- a/src/components/map/component.stories.tsx
+++ b/src/components/map/component.stories.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useState } from 'react';
 
-import { useMap, ViewState, MapProvider } from 'react-map-gl';
+import { ViewState, MapProvider } from 'react-map-gl';
 
 import { Story } from '@storybook/react/types-6-0';
 // Layer manager
@@ -66,28 +66,12 @@ export default StoryMap;
 const cartoProvider = new CartoProvider();
 
 const Template: Story<CustomMapProps> = (args: CustomMapProps) => {
-  const { id, initialViewState, bounds, maxZoom } = args;
+  const { initialViewState, bounds, maxZoom } = args;
   const [viewState, setViewState] = useState<Partial<ViewState>>({});
-  const { [id]: mapRef } = useMap();
 
   const handleViewState = useCallback((vw: ViewState) => {
     setViewState(vw);
   }, []);
-
-  const handleFitBoundsChange = useCallback(
-    (_bounds: CustomMapProps['bounds']) => {
-      const { bbox, options } = _bounds;
-
-      mapRef.fitBounds(
-        [
-          [bbox[0], bbox[1]],
-          [bbox[2], bbox[3]],
-        ],
-        options
-      );
-    },
-    [mapRef]
-  );
 
   return (
     <div className="relative h-screen w-full">
@@ -114,7 +98,7 @@ const Template: Story<CustomMapProps> = (args: CustomMapProps) => {
             </LayerManager>
             <Controls>
               <ZoomControl />
-              <FitBoundsControl bounds={bounds} onFitBoundsChange={handleFitBoundsChange} />
+              <FitBoundsControl bounds={bounds} />
             </Controls>
           </>
         )}
@@ -125,8 +109,6 @@ const Template: Story<CustomMapProps> = (args: CustomMapProps) => {
 
 export const Default = Template.bind({});
 Default.args = {
-  id: 'map-storybook',
-  className: '',
   viewport: {},
   initialViewState: {
     bounds: [10.5194091796875, 43.6499881760459, 10.9588623046875, 44.01257086123085],

--- a/src/components/map/controls/component.stories.tsx
+++ b/src/components/map/controls/component.stories.tsx
@@ -17,7 +17,7 @@ const Template: Story<ControlsProps> = (args) => {
   return (
     <div className="relative h-24">
       <Controls {...args}>
-        <ZoomControl mapId="map-storybook" />
+        <ZoomControl />
 
         <FitBoundsControl
           bounds={{
@@ -38,5 +38,5 @@ const Template: Story<ControlsProps> = (args) => {
 
 export const Default = Template.bind({});
 Default.args = {
-  className: 'w-10 absolute bottom-0 left-0',
+  className: 'absolute bottom-0 left-0',
 };

--- a/src/components/map/controls/component.stories.tsx
+++ b/src/components/map/controls/component.stories.tsx
@@ -17,7 +17,7 @@ const Template: Story<ControlsProps> = (args) => {
   return (
     <div className="relative h-24">
       <Controls {...args}>
-        <ZoomControl mapRef={null} />
+        <ZoomControl mapId="map-storybook" />
 
         <FitBoundsControl
           bounds={{

--- a/src/components/map/controls/component.stories.tsx
+++ b/src/components/map/controls/component.stories.tsx
@@ -27,9 +27,6 @@ const Template: Story<ControlsProps> = (args) => {
               duration: 1500,
             },
           }}
-          onFitBoundsChange={(bounds) => {
-            console.info(bounds);
-          }}
         />
       </Controls>
     </div>

--- a/src/components/map/controls/fit-bounds/component.stories.tsx
+++ b/src/components/map/controls/fit-bounds/component.stories.tsx
@@ -10,14 +10,7 @@ const StoryFitBoundsControl = {
 
 export default StoryFitBoundsControl;
 
-const Template: Story<FitBoundsControlProps> = (args) => (
-  <FitBoundsControl
-    {...args}
-    onFitBoundsChange={(bounds) => {
-      console.info('onFitBoundsChange: ', bounds);
-    }}
-  />
-);
+const Template: Story<FitBoundsControlProps> = (args) => <FitBoundsControl {...args} />;
 
 export const Default = Template.bind({});
 Default.args = {
@@ -25,8 +18,5 @@ Default.args = {
   bounds: {
     bbox: [10.5194091796875, 43.6499881760459, 10.9588623046875, 44.01257086123085],
     options: {},
-  },
-  onFitBoundsChange: (bounds) => {
-    console.info(bounds);
   },
 };

--- a/src/components/map/controls/fit-bounds/component.tsx
+++ b/src/components/map/controls/fit-bounds/component.tsx
@@ -1,4 +1,6 @@
-import { FC, useCallback } from 'react';
+import { FC, useCallback, MouseEvent } from 'react';
+
+import { useMap } from 'react-map-gl';
 
 import cx from 'classnames';
 
@@ -9,21 +11,36 @@ import FIT_BOUNDS_SVG from 'svgs/map/fit-bounds.svg?sprite';
 import type { FitBoundsControlProps } from './types';
 
 export const FitBoundsControl: FC<FitBoundsControlProps> = ({
+  mapId = 'current',
   bounds,
   className,
-  onFitBoundsChange,
 }: FitBoundsControlProps) => {
-  const handleFitBoundsChange = useCallback(() => {
-    onFitBoundsChange(bounds);
-  }, [bounds, onFitBoundsChange]);
+  const { [mapId]: mapRef } = useMap();
+
+  const handleFitBoundsChange = useCallback(
+    (e: MouseEvent<HTMLButtonElement>) => {
+      e.stopPropagation();
+      const { bbox, options } = bounds;
+      if (!mapRef) return null;
+
+      mapRef.fitBounds(
+        [
+          [bbox[0], bbox[1]],
+          [bbox[2], bbox[3]],
+        ],
+        options
+      );
+    },
+    [mapRef, bounds]
+  );
 
   return (
     <button
       aria-label="Fit to bounds"
       className={cx({
-        'mb-0.5 rounded-3xl bg-black px-0.5 py-1 text-white': true,
+        'mb-0.5 rounded-3xl bg-black px-0.5 py-1 text-white disabled:cursor-default disabled:opacity-50':
+          true,
         'hover:bg-gray-700 active:bg-gray-600': !!bounds,
-        'cursor-default opacity-50': !bounds,
         [className]: !!className,
       })}
       type="button"

--- a/src/components/map/controls/fit-bounds/types.d.ts
+++ b/src/components/map/controls/fit-bounds/types.d.ts
@@ -1,7 +1,7 @@
 import type { CustomMapProps } from '../../types';
 
 export interface FitBoundsControlProps {
+  mapId?: string;
   bounds?: CustomMapProps['bounds'];
   className?: string;
-  onFitBoundsChange: (bounds: CustomMapProps['bounds']) => void;
 }

--- a/src/components/map/controls/zoom/component.tsx
+++ b/src/components/map/controls/zoom/component.tsx
@@ -1,5 +1,7 @@
 import { FC, useCallback, MouseEvent } from 'react';
 
+import { useMap } from 'react-map-gl';
+
 import cx from 'classnames';
 
 import Icon from 'components/icon';
@@ -9,7 +11,11 @@ import ZOOM_OUT_SVG from 'svgs/map/zoom-out.svg?sprite';
 
 import type { ZoomControlProps } from './types';
 
-export const ZoomControl: FC<ZoomControlProps> = ({ mapRef, className }: ZoomControlProps) => {
+export const ZoomControl: FC<ZoomControlProps> = ({
+  mapId = 'default',
+  className,
+}: ZoomControlProps) => {
+  const { [mapId]: mapRef } = useMap();
   const zoom = mapRef?.getZoom();
   const minZoom = mapRef?.getMinZoom();
   const maxZoom = mapRef?.getMaxZoom();
@@ -19,11 +25,9 @@ export const ZoomControl: FC<ZoomControlProps> = ({ mapRef, className }: ZoomCon
       e.stopPropagation();
       if (!mapRef) return null;
 
-      if (zoom + 1 <= maxZoom) {
-        mapRef.zoomIn();
-      }
+      mapRef.zoomIn();
     },
-    [mapRef, zoom, maxZoom]
+    [mapRef]
   );
 
   const decreaseZoom = useCallback(
@@ -31,11 +35,9 @@ export const ZoomControl: FC<ZoomControlProps> = ({ mapRef, className }: ZoomCon
       e.stopPropagation();
       if (!mapRef) return null;
 
-      if (zoom + 1 >= minZoom) {
-        mapRef.zoomOut();
-      }
+      mapRef.zoomOut();
     },
-    [mapRef, zoom, minZoom]
+    [mapRef]
   );
 
   return (
@@ -48,12 +50,12 @@ export const ZoomControl: FC<ZoomControlProps> = ({ mapRef, className }: ZoomCon
       <button
         className={cx({
           'mb-0.5 rounded-t-3xl bg-black p-0.5 text-white': true,
-          'hover:bg-gray-700 active:bg-gray-600': zoom !== maxZoom,
-          'cursor-default opacity-50': zoom === maxZoom,
+          'hover:bg-gray-700 active:bg-gray-600': zoom < maxZoom,
+          'cursor-default opacity-50': zoom >= maxZoom,
         })}
         aria-label="Zoom in"
         type="button"
-        disabled={zoom === maxZoom}
+        disabled={zoom >= maxZoom}
         onClick={increaseZoom}
       >
         <Icon icon={ZOOM_IN_SVG} />
@@ -61,12 +63,12 @@ export const ZoomControl: FC<ZoomControlProps> = ({ mapRef, className }: ZoomCon
       <button
         className={cx({
           'rounded-b-3xl bg-black p-0.5 text-white': true,
-          'hover:bg-gray-700 active:bg-gray-600': zoom !== minZoom,
-          'cursor-default opacity-50': zoom === minZoom,
+          'hover:bg-gray-700 active:bg-gray-600': zoom > minZoom,
+          'cursor-default opacity-50': zoom <= minZoom,
         })}
         aria-label="Zoom out"
         type="button"
-        disabled={zoom === minZoom}
+        disabled={zoom <= minZoom}
         onClick={decreaseZoom}
       >
         <Icon icon={ZOOM_OUT_SVG} />

--- a/src/components/map/controls/zoom/component.tsx
+++ b/src/components/map/controls/zoom/component.tsx
@@ -12,7 +12,7 @@ import ZOOM_OUT_SVG from 'svgs/map/zoom-out.svg?sprite';
 import type { ZoomControlProps } from './types';
 
 export const ZoomControl: FC<ZoomControlProps> = ({
-  mapId = 'default',
+  mapId = 'current',
   className,
 }: ZoomControlProps) => {
   const { [mapId]: mapRef } = useMap();

--- a/src/components/map/controls/zoom/component.tsx
+++ b/src/components/map/controls/zoom/component.tsx
@@ -49,9 +49,9 @@ export const ZoomControl: FC<ZoomControlProps> = ({
     >
       <button
         className={cx({
-          'mb-0.5 rounded-t-3xl bg-black p-0.5 text-white': true,
+          'mb-0.5 rounded-t-3xl bg-black p-0.5 text-white disabled:cursor-default disabled:opacity-50':
+            true,
           'hover:bg-gray-700 active:bg-gray-600': zoom < maxZoom,
-          'cursor-default opacity-50': zoom >= maxZoom,
         })}
         aria-label="Zoom in"
         type="button"
@@ -62,9 +62,9 @@ export const ZoomControl: FC<ZoomControlProps> = ({
       </button>
       <button
         className={cx({
-          'rounded-b-3xl bg-black p-0.5 text-white': true,
+          'rounded-b-3xl bg-black p-0.5 text-white disabled:cursor-default disabled:opacity-50':
+            true,
           'hover:bg-gray-700 active:bg-gray-600': zoom > minZoom,
-          'cursor-default opacity-50': zoom <= minZoom,
         })}
         aria-label="Zoom out"
         type="button"

--- a/src/components/map/controls/zoom/types.d.ts
+++ b/src/components/map/controls/zoom/types.d.ts
@@ -1,6 +1,4 @@
-import type { MapRef } from 'react-map-gl';
-
 export interface ZoomControlProps {
-  mapRef: MapRef;
+  mapId?: string;
   className?: string;
 }


### PR DESCRIPTION
- Updates zoom controls to use its own map reference according to the `mapId` passed. Also, it updates zoom logic to rely on the buttons' interactivity to zoom in/out.

- Removed logic that handled disabled styles in `ZoomControls` and `FitBoundsControls` to rely on disabled button state. This way there is a single logic to rely on (the one telling the button when is disabled) and less risk of side effects with several logics.

- Moved `Controls` component and its descendant to `LayerManager` level becoming descendant of `Map` component and granting access to map reference through `current`'s property in `useMap` hook. This way allows using map and controls without declaring any `id` in case there is only a single map on the page. In case there are several maps, passing an id is mandatory to map and controls.

- Removed `onFitBoundsChange` property from `FitBoundsControl` to follow `ZoomControls` behaviour and let the internal map reference handle it.

**Note: I have renamed the property from `id` to `mapId` to not be mistaken with the [HTML attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/id).**

Closes https://github.com/Vizzuality/front-end-scaffold/issues/92