### PR TITLE
Set tsconfigRootDir: __dirname to prevent errors

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -17,6 +17,7 @@ module.exports = {
     },
     ecmaVersion: 12,
     sourceType: 'module',
+    tsconfigRootDir: __dirname,
     project: './tsconfig.eslint.json',
   },
   plugins: ['@typescript-eslint'],


### PR DESCRIPTION
`tsconfigRootDir: __dirname` will prevent eslint errors in VisualStudio code when you are in a subfolder and not the root of the app.