### PR TITLE
docs: removes Headwind from recommended extensions

### DIFF
--- a/docs/tools.stories.mdx
+++ b/docs/tools.stories.mdx
@@ -36,12 +36,6 @@ You **must** install the mandatory extensions listed below. Recommended ones imp
 
 [Marketplace](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint)
 
-
-**HEADWIND** enforces consistent ordering of Tailwind CSS classes by parsing your code and reprinting class.
-
-[Marketplace](https://marketplace.visualstudio.com/items?itemName=heybourn.headwind)
-
-
 **TAILWIND CSS INTELLISENSE** provides a better Tailwind experience with advanced features such as autocomplete, syntax highlighting, and linting.
 
 [Marketplace](https://marketplace.visualstudio.com/items?itemName=bradlc.vscode-tailwindcss)


### PR DESCRIPTION
Removes `headwind` from recommended extensions as we are using `prettier-plugin-tailwindcss` module instead.

Closes #118 